### PR TITLE
Create new monitoring network

### DIFF
--- a/home/bin/ws.service
+++ b/home/bin/ws.service
@@ -22,9 +22,12 @@ bootstrap()
     DIR="$(cd "$(dirname "$0")" && cd ../ && pwd)"
     # shellcheck source=../lib/sidekick.sh
     source "$DIR/lib/sidekick.sh"
+    if ! docker network ls -f name="${TRAEFIK_NETWORK}" | grep -q "${TRAEFIK_NETWORK}"; then
+        run docker network create "${TRAEFIK_NETWORK}"
+    fi
 
-    if ! docker network ls | grep "${TRAEFIK_NETWORK}" > /dev/null; then
-        run docker network create "$TRAEFIK_NETWORK"
+    if ! docker network ls -f name="${TRAEFIK_NETWORK}_monitoring" | grep -q "${TRAEFIK_NETWORK}_monitoring"; then
+        run docker network create "${TRAEFIK_NETWORK}_monitoring"
     fi
 }
 

--- a/home/service/logger/docker-compose.yml
+++ b/home/service/logger/docker-compose.yml
@@ -5,20 +5,16 @@ services:
   kibana:
     build:
       context: kibana
-    depends_on:
-      - elasticsearch
+    links:
+      - elasticsearch:elasticsearch
     labels:
       - traefik.backend=kibana
       - traefik.frontend.rule=Host:kibana.my127.site
       - traefik.docker.network=${TRAEFIK_NETWORK}
       - traefik.port=5601
     networks:
-      shared:
-        aliases:
-          - monitoring_kibana
-      private:
-        aliases:
-          - kibana
+      - private
+      - shared
 
   elasticsearch:
     build:
@@ -28,9 +24,7 @@ services:
     labels:
       - traefik.enable=false
     networks:
-      private:
-        aliases:
-          - elasticsearch
+      - private
 
   filebeat:
     build:
@@ -45,9 +39,7 @@ services:
     labels:
       - traefik.enable=false
     networks:
-      private:
-        aliases:
-          - filebeat
+      - private
 
   metricbeat:
     build:
@@ -63,12 +55,8 @@ services:
     labels:
       - traefik.enable=false
     networks:
-      private:
-        aliases:
-          - metricbeat
-      monitoring:
-        aliases:
-          - monitoring_metricbeat
+      - private
+      - monitoring
 
 volumes:
   filebeat_data: ~

--- a/home/service/logger/docker-compose.yml
+++ b/home/service/logger/docker-compose.yml
@@ -13,8 +13,12 @@ services:
       - traefik.docker.network=${TRAEFIK_NETWORK}
       - traefik.port=5601
     networks:
-      - shared
-      - private
+      shared:
+        aliases:
+          - monitoring_kibana
+      private:
+        aliases:
+          - kibana
 
   elasticsearch:
     build:
@@ -24,7 +28,9 @@ services:
     labels:
       - traefik.enable=false
     networks:
-      - private
+      private:
+        aliases:
+          - elasticsearch
 
   filebeat:
     build:
@@ -39,7 +45,9 @@ services:
     labels:
       - traefik.enable=false
     networks:
-      - private
+      private:
+        aliases:
+          - filebeat
 
   metricbeat:
     build:
@@ -55,8 +63,12 @@ services:
     labels:
       - traefik.enable=false
     networks:
-      - private
-      - shared
+      private:
+        aliases:
+          - metricbeat
+      monitoring:
+        aliases:
+          - monitoring_metricbeat
 
 volumes:
   filebeat_data: ~
@@ -64,6 +76,9 @@ volumes:
 networks:
   private:
     external: false
+  monitoring:
+    external:
+      name: ${TRAEFIK_NETWORK}_monitoring
   shared:
     external:
-      name: $TRAEFIK_NETWORK
+      name: ${TRAEFIK_NETWORK}

--- a/home/service/mail/docker-compose.yml
+++ b/home/service/mail/docker-compose.yml
@@ -7,8 +7,12 @@ services:
       - traefik.frontend.rule=Host:mail.my127.site
       - traefik.port=8025
     networks:
-      - private
-      - shared
+      private:
+        aliases:
+          - mailhog
+      shared:
+        aliases:
+          - global_mailhog
 networks:
   private:
     external: false

--- a/home/service/mail/docker-compose.yml
+++ b/home/service/mail/docker-compose.yml
@@ -7,12 +7,8 @@ services:
       - traefik.frontend.rule=Host:mail.my127.site
       - traefik.port=8025
     networks:
-      private:
-        aliases:
-          - mailhog
-      shared:
-        aliases:
-          - global_mailhog
+      - private
+      - shared
 networks:
   private:
     external: false

--- a/home/service/proxy/docker-compose.yml
+++ b/home/service/proxy/docker-compose.yml
@@ -16,8 +16,15 @@ services:
       - ~/.config/my127ws/proxy:/config
       - ./traefik/root/tls:/tls
     networks:
-      - private
-      - shared
+      private:
+        aliases:
+          - traefik
+      shared:
+        aliases:
+          - global_traefik
+      monitoring:
+        aliases:
+          - global_traefik
     command: ['--docker']
 networks:
   private:
@@ -25,3 +32,6 @@ networks:
   shared:
     external:
       name: $TRAEFIK_NETWORK
+  monitoring:
+    external:
+      name: ${TRAEFIK_NETWORK}_monitoring

--- a/home/service/proxy/docker-compose.yml
+++ b/home/service/proxy/docker-compose.yml
@@ -16,15 +16,9 @@ services:
       - ~/.config/my127ws/proxy:/config
       - ./traefik/root/tls:/tls
     networks:
-      private:
-        aliases:
-          - traefik
-      shared:
-        aliases:
-          - global_traefik
-      monitoring:
-        aliases:
-          - global_traefik
+      - private
+      - shared
+      - monitoring
     command: ['--docker']
 networks:
   private:


### PR DESCRIPTION
Traefik talks to nginx in the my127ws namespace.

If two environments are running at once, the nginx DNS address is load balanced between the two environments.

Use a separate namespace for monitoring to help alleviate this.