### PR TITLE
Upgrade python in AWS image

### DIFF
--- a/home/utility/aws/Dockerfile
+++ b/home/utility/aws/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:2-alpine
+FROM python:3-alpine
 
 RUN apk add --no-cache bash shadow groff
 


### PR DESCRIPTION
Avoids a warning from pip:
```
DEPRECATION: Python 2.7 will reach the end of its life on January 1st, 2020. Please upgrade your Python as Python 2.7 won't be maintained after that date. A future version of pip will drop support for Python 2.7.
```