### PR TITLE
Allow tests to be run on macOS

### DIFF
--- a/tests/Fixture.php
+++ b/tests/Fixture.php
@@ -4,43 +4,51 @@ use my127\Workspace\Utility\Filesystem;
 
 class Fixture
 {
-    private const WORKSPACE_DIR = '/tmp/my127ws.phpuint';
+    private static $WORKSPACE_DIR = '/tmp/my127ws.phpunit';
 
     private static function clean()
     {
-        if (is_dir(self::WORKSPACE_DIR)) {
-            Filesystem::rrmdir(self::WORKSPACE_DIR);
+        if (is_dir(self::$WORKSPACE_DIR)) {
+            Filesystem::rrmdir(self::$WORKSPACE_DIR);
         }
 
-        mkdir(self::WORKSPACE_DIR, 0755, true);
+        mkdir(self::$WORKSPACE_DIR, 0755, true);
+    }
+
+    private static function workspaceDir()
+    {
+        $macPrivateDir = php_uname('s') == 'Darwin' ? '/private' : '';
+        self::$WORKSPACE_DIR = $macPrivateDir . sys_get_temp_dir() . '/my127ws.phpunit';
     }
 
     public static function sampleData($name): string
     {
         self::clean();
+        self::workspaceDir();
 
         if (!is_dir($src = __DIR__.'/samples/'.$name)) {
             throw new Exception("Fixture '{$name}' not found.");
         }
 
-        Filesystem::rcopy($src, self::WORKSPACE_DIR);
-        chdir(self::WORKSPACE_DIR);
-        return self::WORKSPACE_DIR;
+        Filesystem::rcopy($src, self::$WORKSPACE_DIR);
+        chdir(self::$WORKSPACE_DIR);
+        return self::$WORKSPACE_DIR;
     }
 
     public static function workspace($declarations)
     {
         self::clean();
-        file_put_contents(self::WORKSPACE_DIR.'/workspace.yml', $declarations);
-        chdir(self::WORKSPACE_DIR);
-        return self::WORKSPACE_DIR;
+        self::workspaceDir();
+        file_put_contents(self::$WORKSPACE_DIR.'/workspace.yml', $declarations);
+        chdir(self::$WORKSPACE_DIR);
+        return self::$WORKSPACE_DIR;
     }
 
     public static function workspaceWithSampleData($declarations, $sample)
     {
         self::sampleData($sample);
-        file_put_contents(self::WORKSPACE_DIR.'/workspace.yml', $declarations);
-        chdir(self::WORKSPACE_DIR);
-        return self::WORKSPACE_DIR;
+        file_put_contents(self::$WORKSPACE_DIR.'/workspace.yml', $declarations);
+        chdir(self::$WORKSPACE_DIR);
+        return self::$WORKSPACE_DIR;
     }
 }

--- a/tests/Test/Types/WorkspaceTest.php
+++ b/tests/Test/Types/WorkspaceTest.php
@@ -83,15 +83,15 @@ EOD
     public function workspace_exec_method_is_made_available_to_expressions()
     {
         Fixture::workspace(<<<'EOD'
-attribute('message'): = exec("echo -n 'Hello World'")
+attribute('message'): = exec("echo 'Hello World'")
         
 command('speak'): |
   #!bash|@
-  echo -n "@('message')"
+  echo "@('message')"
 EOD
         );
 
-        $this->assertEquals("Hello World", run('speak'));
+        $this->assertEquals("Hello World\n", run('speak'));
     }
 
     /** @test */
@@ -100,10 +100,10 @@ EOD
         Fixture::workspace(<<<'EOD'
 command('speak'): |
   #!php
-  $ws->passthru('echo -n "Hello World"');
+  $ws->passthru('echo "Hello World"');
 EOD
         );
 
-        $this->assertEquals("Hello World", run('speak'));
+        $this->assertEquals("Hello World\n", run('speak'));
     }
 }


### PR DESCRIPTION
/tmp is a symlink to /private/var/folders/RANDOMCHARS/

According to https://reactphp.org/child-process/ php uses a "sh" shellwrapper
around all commands, of which sh's echo does not support "-n" to suppress
the newline.