### PR TITLE
Fix stty size - fixes line wrapping in `ws console`

### DIFF
--- a/src/Interpreter/Executors/Bash/Executor.php
+++ b/src/Interpreter/Executors/Bash/Executor.php
@@ -10,7 +10,19 @@ class Executor implements InterpreterExecutor
 
     public function exec(string $script, array $args = [], string $cwd = null, array $env = []): void
     {
-        passthru($this->buildCommand($script, $args, $cwd, $env), $status);
+        $descriptorSpec = [
+            0 => STDIN,
+            1 => STDOUT,
+            2 => STDERR
+        ];
+
+        $pipes = [];
+        $process = proc_open($this->buildCommand($script, $args, $cwd, $env), $descriptorSpec, $pipes);
+
+        $status = 255;
+        if (is_resource($process)) {
+            $status = proc_close($process);
+        }
 
         if ($status !== 0) {
             exit($status);


### PR DESCRIPTION
Docker detects if stdin is a stream for it to activate it's stty settings.
`passthru()` appears to convince docker it is not available.

`proc_open()` seems to let it through fine though, and `stty size` shows
the correct terminal columns/lines. Resizing the terminal window also
updates `stty size` correctly.