### PR TITLE
Fix subscribers that use environment variables.

### DIFF
--- a/docs/types/subscriber.md
+++ b/docs/types/subscriber.md
@@ -7,7 +7,7 @@ There are several built-in events, you can also dispatch your own. Subscribers a
 ```
 on('event.name'):
   env:
-    - NAME: Value
+    NAME: Value
   exec: |
     #!interpreter(path:/location)|filter
     script
@@ -33,7 +33,7 @@ Note: The event name in the above example would be `after.harness.install`.
 on('my.event'): |
   #!bash
   echo "This is my custom event."
-  
+
 command('hi'): |
   #!php
   $ws->trigger('my.event');

--- a/src/Interpreter/Script.php
+++ b/src/Interpreter/Script.php
@@ -34,7 +34,7 @@ class Script
         return $this->executor->capture($this->script, $this->buildArgList($args), $this->cwd, $env);
     }
 
-    private function buildArgList(?array $args)
+    private function buildArgList(?array $args) : array
     {
         if (null === $args) {
             return [];

--- a/src/Types/Subscriber/Subscriber.php
+++ b/src/Types/Subscriber/Subscriber.php
@@ -28,7 +28,7 @@ class Subscriber
         $env    = $this->evaluateEnvironmentVariables($this->definition->getEnvironmentVariables());
         $script = $this->definition->getExec();
 
-        $this->interpreter->script($script)->exec($env);
+        $this->interpreter->script($script)->exec([], $env);
     }
 
     private function evaluateEnvironmentVariables(array $env): array

--- a/tests/Test/Types/SubscriberTest.php
+++ b/tests/Test/Types/SubscriberTest.php
@@ -25,6 +25,26 @@ EOD
     }
 
     /** @test */
+    public function subscriber_script_is_run_with_env_when_triggered()
+    {
+        Fixture::workspace(<<<'EOD'
+on('custom.event'):
+  env:
+    EXAMPLE: test
+  exec: |
+    #!bash
+    echo -n "Hello World, $EXAMPLE"
+
+command('hi'): |
+  #!php
+  $ws->trigger('custom.event');
+EOD
+        );
+
+        $this->assertEquals("Hello World, test", run('hi'));
+    }
+
+    /** @test */
     public function after_can_be_used_as_a_shorthand_for_event_names_prefixed_with_after()
     {
         Fixture::workspace(<<<'EOD'


### PR DESCRIPTION
[array_combine](https://www.php.net/manual/en/function.array-combine.php) needs two arrays of equal length - one for keys, one for values.

The environment part of a subscriber was being passed in as arguments for the script, which didn't tally with $this->arguments, leading to:
```
PHP Warning:  array_combine(): Both parameters should have an equal number of elements in /Users/kevans/Repositories/ws/workspace/src/Interpreter/Script.php on line 43

Warning: array_combine(): Both parameters should have an equal number of elements in /Users/kevans/Repositories/ws/workspace/src/Interpreter/Script.php on line 43
PHP Fatal error:  Uncaught TypeError: Argument 2 passed to my127\Workspace\Interpreter\Executors\Bash\Executor::exec() must be of the type array, bool given, called in /Users/kevans/Repositories/ws/workspace/src/Interpreter/Script.php on line 29 and defined in /Users/kevans/Repositories/ws/workspace/src/Interpreter/Executors/Bash/Executor.php:11
Stack trace:
#0 /Users/kevans/Repositories/ws/workspace/src/Interpreter/Script.php(29): my127\Workspace\Interpreter\Executors\Bash\Executor->exec('#!bash\ndocker-c...', false, '/Users/kevans/S...', Array)
#1 /Users/kevans/Repositories/ws/workspace/src/Types/Subscriber/Subscriber.php(31): my127\Workspace\Interpreter\Script->exec(Array)
#2 /Users/kevans/Repositories/ws/workspace/vendor/symfony/event-dispatcher/EventDispatcher.php(212): my127\Workspace\Types\Subscriber\Subscriber->__invoke(Object(Symfony\Component\EventDispatcher\Event), 'harness.install...', Object(Symfony\Component\EventDispatcher\EventDispatcher))
#3 /Users/kevans/Repositories/ws/workspace/vendor/symfony/event-dispatch in /Users/kevans/Repositories/ws/workspace/src/Interpreter/Executors/Bash/Executor.php on line 11

Fatal error: Uncaught TypeError: Argument 2 passed to my127\Workspace\Interpreter\Executors\Bash\Executor::exec() must be of the type array, bool given, called in /Users/kevans/Repositories/ws/workspace/src/Interpreter/Script.php on line 29 and defined in /Users/kevans/Repositories/ws/workspace/src/Interpreter/Executors/Bash/Executor.php:11
Stack trace:
#0 /Users/kevans/Repositories/ws/workspace/src/Interpreter/Script.php(29): my127\Workspace\Interpreter\Executors\Bash\Executor->exec('#!bash\ndocker-c...', false, '/Users/kevans/S...', Array)
#1 /Users/kevans/Repositories/ws/workspace/src/Types/Subscriber/Subscriber.php(31): my127\Workspace\Interpreter\Script->exec(Array)
#2 /Users/kevans/Repositories/ws/workspace/vendor/symfony/event-dispatcher/EventDispatcher.php(212): my127\Workspace\Types\Subscriber\Subscriber->__invoke(Object(Symfony\Component\EventDispatcher\Event), 'harness.install...', Object(Symfony\Component\EventDispatcher\EventDispatcher))
#3 /Users/kevans/Repositories/ws/workspace/vendor/symfony/event-dispatch in /Users/kevans/Repositories/ws/workspace/src/Interpreter/Executors/Bash/Executor.php on line 11
```