### PR TITLE
Reduce return-type constraints of dynamic functions

### DIFF
--- a/src/Interpreter/Executor.php
+++ b/src/Interpreter/Executor.php
@@ -5,6 +5,6 @@ namespace my127\Workspace\Interpreter;
 interface Executor
 {
     public function exec(string $script, array $args = [], string $cwd = null, array $env = []): void;
-    public function capture(string $script, array $args = [], string $cwd = null, array $env = []): string;
+    public function capture(string $script, array $args = [], string $cwd = null, array $env = []);
     public function getName(): string;
 }

--- a/src/Interpreter/Executors/PHP/Executor.php
+++ b/src/Interpreter/Executors/PHP/Executor.php
@@ -19,7 +19,7 @@ class Executor implements InterpreterExecutor
         $this->run($script, $args, $cwd, $env);
     }
 
-    public function capture(string $script, array $args = [], string $cwd = null, array $env = []): string
+    public function capture(string $script, array $args = [], string $cwd = null, array $env = [])
     {
         $pos = strrpos($script, "\n") + 1;
 

--- a/src/Interpreter/Script.php
+++ b/src/Interpreter/Script.php
@@ -29,7 +29,7 @@ class Script
         $this->executor->exec($this->script, $this->buildArgList($args), $this->cwd, $env);
     }
 
-    public function capture(?array $args = [], ?array $env = []): string
+    public function capture(?array $args = [], ?array $env = [])
     {
         return $this->executor->capture($this->script, $this->buildArgList($args), $this->cwd, $env);
     }

--- a/tests/Test/Types/FunctionTest.php
+++ b/tests/Test/Types/FunctionTest.php
@@ -100,4 +100,21 @@ EOD
 
         $this->assertEquals("4", run('hi'));
     }
+
+    /** @test */
+    public function functions_are_able_to_return_non_scalar_types()
+    {
+        Fixture::workspace(<<<'EOD'
+function('array', [v1, v2]): |
+  #!php
+  = [$v1, $v2];
+
+command('array <v1> <v2>'): |
+  #!php
+  echo json_encode($ws->array($input->getArgument('v1'), $input->getArgument('v2')));
+EOD
+        );
+
+        $this->assertEquals('["2","2"]', run('array 2 2'));
+    }
 }


### PR DESCRIPTION
Allows functions to return other scalar types, arrays and objects, matching Twig capabilities