### PR TITLE
Turn off html autoescape

### DIFF
--- a/src/Twig/EnvironmentBuilder.php
+++ b/src/Twig/EnvironmentBuilder.php
@@ -38,7 +38,9 @@ class EnvironmentBuilder
         $directory = $this->path->getRealPath($path);
 
         $loader      = new Filesystem([$directory], $directory);
-        $environment = new Twig_Environment($loader);
+        $environment = new Twig_Environment($loader, [
+            'autoescape' => false
+        ]);
 
         foreach ($this->functions as $function) {
             $environment->addFunction($function);


### PR DESCRIPTION
Workspace harnesses almost never need html escaping in twig templates, so have to be dotted with tonnes of `| raw` filters or switching to the right autoescape method for the file or off at file level.

It makes more sense to not have it enabled in the first place