### PR TITLE
WIP Add support for with_items for rendering multiple files from one

### DIFF
--- a/src/Types/Confd/Confd.php
+++ b/src/Types/Confd/Confd.php
@@ -4,7 +4,7 @@ namespace my127\Workspace\Types\Confd;
 
 use my127\Workspace\Expression\Expression;
 use my127\Workspace\Path\Path;
-use my127\Workspace\Twig\Loader\Filesystem;
+use Symfony\Component\Config\Definition\Exception\Exception;
 use Twig_Environment;
 
 class Confd
@@ -32,27 +32,40 @@ class Confd
     public function apply(): void
     {
         foreach ($this->definition->getTemplates() as $path) {
+            if (isset($path['with_items'])) {
+                if (!is_iterable($path['with_items'])) {
+                    throw new Exception("Expected with_items to be iterable");
+                }
 
-            if (isset($path['when']) && $this->expression->evaluate($path['when']) === false) {
-                continue;
-            }
-
-            if (is_string($path)) {
-                $src = $path.'.twig';
-                $dst = $this->resolveDstFromSrc($src);
+                foreach ($path['with_items'] as $key => $item) {
+                    $this->applyPath($path, ['key' => $key, 'item' => $item]);
+                }
             } else {
-                $src = $path['src'].'.twig';
-                $dst = isset($path['dst']) ? $this->path->getRealPath($path['dst']) : $this->resolveDstFromSrc($src);
+                $this->applyPath($path);
             }
-
-            $dir = dirname($dst);
-
-            if (!is_dir($dir)) {
-                mkdir($dir, 0755, true);
-            }
-
-            file_put_contents($dst, $this->twig->render($src));
         }
+    }
+
+    private function applyPath(string $path, array $values = []): void {
+        if (isset($path['when']) && $this->expression->evaluate($path['when'], $values) === false) {
+            return;
+        }
+
+        if (is_string($path)) {
+            $src = $path.'.twig';
+            $dst = $this->resolveDstFromSrc($src);
+        } else {
+            $src = $path['src'].'.twig';
+            $dst = isset($path['dst']) ? $this->path->getRealPath($path['dst']) : $this->resolveDstFromSrc($src);
+        }
+
+        $dir = dirname($dst);
+
+        if (!is_dir($dir)) {
+            mkdir($dir, 0755, true);
+        }
+
+        file_put_contents($dst, $this->twig->render($src, $values));
     }
 
     private function resolveDstFromSrc(string $path): string


### PR DESCRIPTION
Similar to ansible's with_items, it adds a `item` variable
Additionally since PHP arrays can be key => value pairs, it adds a `key` variable

These are available then within `when` expressions, `src` and `dst` when used as an expression, and within the template