### PR TITLE
Add missing Bash interpreter page

### DIFF
--- a/docs/interpreters/bash.md
+++ b/docs/interpreters/bash.md
@@ -1,0 +1,3 @@
+# Interpreter - Bash
+
+TODO


### PR DESCRIPTION
Add the missing Bash interpreter page, as this is currently 404-ing on
the link within the README.

The page has just a 'TODO' comment in it at the moment, but I think that
this is better than the page not existing at all.

References #48