### PR TITLE
Fix multiple argument run/passthru escaping

### DIFF
--- a/home/bin/ws.aws
+++ b/home/bin/ws.aws
@@ -10,7 +10,7 @@ main()
         AWS_ACCESS_KEY_ID="$AWS_ID" AWS_SECRET_ACCESS_KEY="$AWS_KEY" aws "$@"
     else
         if ! docker image ls my127ws-aws | grep -q my127ws-aws; then
-            run "docker build -t my127ws-aws '$DIR/utility/aws'"
+            run docker build -t my127ws-aws "$DIR/utility/aws"
         fi
         docker run --user "$UID:$UID" --env AWS_ACCESS_KEY_ID="$AWS_ID" --env AWS_SECRET_ACCESS_KEY="$AWS_KEY" -v "$PWD:/mount" --rm my127ws-aws aws "$@"
     fi

--- a/home/lib/sidekick.sh
+++ b/home/lib/sidekick.sh
@@ -20,13 +20,16 @@ prompt()
 run()
 {
     local -r COMMAND_DEPRECATED="$*"
-    local -r COMMAND="$@"
+    local -r COMMAND=("$@")
     local DEPRECATED_MODE=no
 
     if [[ "${COMMAND[0]}" = *" "* ]]; then
-      echo "deprecated: support for passing multiple arguments in passthru '${COMMAND_DEPRECATED[*]}' will be removed in a future version" >&2
-      echo "a future major version will only support passthru ${COMMAND_DEPRECATED[*]}" >&2
-      DEPRECATED_MODE=yes
+        echo "deprecated: support for passing multiple arguments in the following line will be removed in a future version" >&2
+        echo "run '${COMMAND_DEPRECATED[*]}'" >&2
+        echo "a future major version will only support:" >&2
+        echo "run ${COMMAND_DEPRECATED[*]}" >&2
+        echo >&2
+        DEPRECATED_MODE=yes
     fi
 
     if [ "$VERBOSE" = "no" ]; then
@@ -42,7 +45,7 @@ run()
             "${COMMAND[@]}" > /tmp/my127ws-stdout.txt 2> /tmp/my127ws-stderr.txt
         fi
 
-        if [ "$?" -gt 0 ] then
+        if [ "$?" -gt 0 ]; then
             setCommandIndicator "${INDICATOR_ERROR}"
 
             cat /tmp/my127ws-stderr.txt
@@ -66,12 +69,15 @@ run()
 passthru()
 {
     local -r COMMAND_DEPRECATED="$*"
-    local -r COMMAND="$@"
+    local -r COMMAND=("$@")
     local DEPRECATED_MODE=no
 
     if [[ "${COMMAND[0]}" = *" "* ]]; then
-        echo "deprecated: support for passing multiple arguments in passthru '${COMMAND_DEPRECATED[*]}' will be removed in a future version" >&2
-        echo "a future major version will only support passthru ${COMMAND_DEPRECATED[*]}" >&2
+        echo "deprecated: support for passing multiple arguments in the following line will be removed in a future version" >&2
+        echo "passthru '${COMMAND_DEPRECATED[*]}'" >&2
+        echo "a future major version will only support:" >&2
+        echo "passthru ${COMMAND_DEPRECATED[*]}" >&2
+        echo >&2
         DEPRECATED_MODE=yes
     fi
 

--- a/home/lib/sidekick.sh
+++ b/home/lib/sidekick.sh
@@ -75,7 +75,7 @@ passthru()
 
     if [ "${DEPRECATED_MODE}" = "yes" ]; then
         echo -e "\\033[${INDICATOR_PASSTHRU}■\\033[0m > $*" >&2
-        if ! bash -e -c "${COMMAND_DEPRECATED[@]}" >&2; then
+        if ! bash -e -c "${COMMAND_DEPRECATED[@]}"; then
             exit 1
         fi
     else

--- a/home/lib/sidekick.sh
+++ b/home/lib/sidekick.sh
@@ -85,10 +85,14 @@ passthru()
 
     if [ "${DEPRECATED_MODE}" = "yes" ]; then
         echo -e "\\033[${INDICATOR_PASSTHRU}■\\033[0m > $*" >&2
-        bash -e -c "${COMMAND_DEPRECATED[@]}" >&2
+        if ! bash -e -c "${COMMAND_DEPRECATED[@]}" >&2; then
+            exit 1
+        fi
     else
         echo -e "\\033[${INDICATOR_PASSTHRU}■\\033[0m >$(printf ' %q' "${COMMAND[@]}")" >&2
-        "${COMMAND[@]}"
+        if ! "${COMMAND[@]}"; then
+            exit 1
+        fi
     fi
 }
 

--- a/home/lib/sidekick.sh
+++ b/home/lib/sidekick.sh
@@ -24,11 +24,6 @@ run()
     local DEPRECATED_MODE=no
 
     if [[ "${COMMAND[0]}" = *" "* ]]; then
-        echo "deprecated: support for passing multiple arguments in the following line will be removed in a future version" >&2
-        echo "run '${COMMAND_DEPRECATED[*]}'" >&2
-        echo "a future major version will only support:" >&2
-        echo "run ${COMMAND_DEPRECATED[*]}" >&2
-        echo >&2
         DEPRECATED_MODE=yes
     fi
 
@@ -73,11 +68,6 @@ passthru()
     local DEPRECATED_MODE=no
 
     if [[ "${COMMAND[0]}" = *" "* ]]; then
-        echo "deprecated: support for passing multiple arguments in the following line will be removed in a future version" >&2
-        echo "passthru '${COMMAND_DEPRECATED[*]}'" >&2
-        echo "a future major version will only support:" >&2
-        echo "passthru ${COMMAND_DEPRECATED[*]}" >&2
-        echo >&2
         DEPRECATED_MODE=yes
     fi
 

--- a/home/lib/sidekick.sh
+++ b/home/lib/sidekick.sh
@@ -13,7 +13,7 @@ prompt()
 {
     if [ "${RUN_CWD}" != "$(pwd)" ]; then
         RUN_CWD="$(pwd)"
-        echo -e "\\033[1m[\\033[0m$(pwd)\\033[1m]:\\033[0m"
+        echo -e "\\033[1m[\\033[0m$(pwd)\\033[1m]:\\033[0m" >&2
     fi
 }
 
@@ -36,11 +36,11 @@ run()
 
         prompt
         if [ "${DEPRECATED_MODE}" = "yes" ]; then
-            echo "  > ${COMMAND_DEPRECATED[*]}"
+            echo "  > ${COMMAND_DEPRECATED[*]}" >&2
             setCommandIndicator "${INDICATOR_RUNNING}"
             bash -c "${COMMAND_DEPRECATED[@]}" > /tmp/my127ws-stdout.txt 2> /tmp/my127ws-stderr.txt
         else
-            echo "  >$(printf ' %q' "${COMMAND[@]}")"
+            echo "  >$(printf ' %q' "${COMMAND[@]}")" >&2
             setCommandIndicator "${INDICATOR_RUNNING}"
             "${COMMAND[@]}" > /tmp/my127ws-stdout.txt 2> /tmp/my127ws-stderr.txt
         fi
@@ -50,10 +50,10 @@ run()
 
             cat /tmp/my127ws-stderr.txt
 
-            echo "----------------------------------"
-            echo "Full Logs :-"
-            echo "  stdout: /tmp/my127ws-stdout.txt"
-            echo "  stderr: /tmp/my127ws-stderr.txt"
+            echo "----------------------------------" >&2
+            echo "Full Logs :-" >&2
+            echo "  stdout: /tmp/my127ws-stdout.txt" >&2
+            echo "  stderr: /tmp/my127ws-stderr.txt" >&2
 
             exit 1
         else
@@ -84,19 +84,19 @@ passthru()
     prompt
 
     if [ "${DEPRECATED_MODE}" = "yes" ]; then
-        echo -e "\\033[${INDICATOR_PASSTHRU}■\\033[0m > $*"
-        bash -e -c "${COMMAND_DEPRECATED[@]}"
+        echo -e "\\033[${INDICATOR_PASSTHRU}■\\033[0m > $*" >&2
+        bash -e -c "${COMMAND_DEPRECATED[@]}" >&2
     else
-        echo -e "\\033[${INDICATOR_PASSTHRU}■\\033[0m >$(printf ' %q' "${COMMAND[@]}")"
+        echo -e "\\033[${INDICATOR_PASSTHRU}■\\033[0m >$(printf ' %q' "${COMMAND[@]}")" >&2
         "${COMMAND[@]}"
     fi
 }
 
 setCommandIndicator()
 {
-    echo -ne "\\033[1A";
-    echo -ne "\\033[$1"
-    echo -n "■"
-    echo -ne "\\033[0m"
-    echo -ne "\\033[1E";
+    echo -ne "\\033[1A" >&2 
+    echo -ne "\\033[$1" >&2
+    echo -n "■" >&2
+    echo -ne "\\033[0m" >&2
+    echo -ne "\\033[1E" >&2
 }

--- a/home/service/proxy/init.sh
+++ b/home/service/proxy/init.sh
@@ -32,8 +32,8 @@ enable()
             run mkdir -p traefik/root/tls
         fi
 
-        run bash -c "curl $(ws global config get global.service.proxy.https.crt) > traefik/root/tls/my127.site.crt"
-        run bash -c "curl $(ws global config get global.service.proxy.https.key) > traefik/root/tls/my127.site.key"
+        run curl --fail --location --output traefik/root/tls/my127.site.crt "$(ws global config get global.service.proxy.https.crt)"
+        run curl --fail --location --output traefik/root/tls/my127.site.key "$(ws global config get global.service.proxy.https.key)"
         run docker-compose -p my127ws-proxy rm --force traefik
         run docker-compose -p my127ws-proxy up --build -d traefik
     fi

--- a/home/service/proxy/init.sh
+++ b/home/service/proxy/init.sh
@@ -29,13 +29,13 @@ enable()
     if ! docker ps | grep my127ws-proxy > /dev/null; then
 
         if [ ! -d "traefik/root/tls" ]; then
-            run "mkdir -p traefik/root/tls"
+            run mkdir -p traefik/root/tls
         fi
 
-        run "curl $(ws global config get global.service.proxy.https.crt) > traefik/root/tls/my127.site.crt"
-        run "curl $(ws global config get global.service.proxy.https.key) > traefik/root/tls/my127.site.key"
-        run "docker-compose -p my127ws-proxy rm --force traefik"
-        run "docker-compose -p my127ws-proxy up --build -d traefik"
+        run bash -c "curl $(ws global config get global.service.proxy.https.crt) > traefik/root/tls/my127.site.crt"
+        run bash -c "curl $(ws global config get global.service.proxy.https.key) > traefik/root/tls/my127.site.key"
+        run docker-compose -p my127ws-proxy rm --force traefik
+        run docker-compose -p my127ws-proxy up --build -d traefik
     fi
 )
 
@@ -44,7 +44,7 @@ disable()
     cd "$DIR"
 
     if docker ps | grep my127ws-proxy > /dev/null; then
-        run "docker-compose -p my127ws-proxy rm --stop --force traefik"
+        run docker-compose -p my127ws-proxy rm --stop --force traefik
     fi
 )
 


### PR DESCRIPTION
* Multiple argument run/passthru was splitting arguments with spaces in, and losing empty arguments
* Single argument run/passthru may be deprecated later