### PR TITLE
Silence the exit code shellcheck

### DIFF
--- a/home/lib/sidekick.sh
+++ b/home/lib/sidekick.sh
@@ -40,6 +40,7 @@ run()
             "${COMMAND[@]}" > /tmp/my127ws-stdout.txt 2> /tmp/my127ws-stderr.txt
         fi
 
+        # shellcheck disable=SC2181
         if [ "$?" -gt 0 ]; then
             setCommandIndicator "${INDICATOR_ERROR}"
 


### PR DESCRIPTION
This is the only reasonable way of doing this asside from extracting the if block out to another function that will make it look more complex in bash