### PR TITLE
Support asking for filepaths during `ws create`

### DIFF
--- a/src/Terminal/Terminal.php
+++ b/src/Terminal/Terminal.php
@@ -22,9 +22,8 @@ class Terminal
 
     public function ask(string $message, $default = null)
     {
-        $response = $this->question->ask($this->argv, $this->output, new Question($message . ': '));
-
-        return (!empty($response)) ? $response : $default;
+        $response = $this->question->ask($this->argv, $this->output, new Question($message.': ', $default));
+        return (!empty($response))?$response:$default;
     }
 
     public function write(string $line)

--- a/src/Terminal/Terminal.php
+++ b/src/Terminal/Terminal.php
@@ -22,8 +22,9 @@ class Terminal
 
     public function ask(string $message, $default = null)
     {
-        $response = $this->question->ask($this->argv, $this->output, new Question($message.': ', $default));
-        return (!empty($response))?$response:$default;
+        $response = $this->question->ask($this->argv, $this->output, new Question($message . ': ', $default));
+
+        return (!empty($response)) ? $response : $default;
     }
 
     public function write(string $line)

--- a/src/Types/Crypt/Builder.php
+++ b/src/Types/Crypt/Builder.php
@@ -61,13 +61,17 @@ class Builder implements EnvironmentBuilder
         });
 
         if ($definitions->hasType(KeyDefinition::TYPE)) {
+
+            $this->application->section('secret encrypt-file')
+                ->usage('secret encrypt-file <path_to_file> [<key>]')
+                ->action(function (Input $input) {
+                    echo $this->crypt->encrypt(file_get_contents($input->getArgument('path_to_file')), $input->getArgument('key') ?? 'default') . "\n";
+                });
+
             $this->application->section('secret encrypt')
                 ->usage('secret encrypt <message> [<key>]')
                 ->action(function (Input $input) {
-                    $key = $input->getArgument('key');
-                    $key = $key instanceof OptionValue ? $key->value() : $key;
-                    $key = $key ?? 'default';
-                    echo $this->crypt->encrypt($input->getArgument('message'), $key) . "\n";
+                    echo $this->crypt->encrypt($input->getArgument('message'), $input->getArgument('key') ?? 'default') . "\n";
                 });
 
             $this->application->section('secret decrypt')

--- a/src/Types/Crypt/Builder.php
+++ b/src/Types/Crypt/Builder.php
@@ -4,7 +4,6 @@ namespace my127\Workspace\Types\Crypt;
 
 use Exception;
 use my127\Console\Usage\Input;
-use my127\Console\Usage\Model\OptionValue;
 use my127\Workspace\Application;
 use my127\Workspace\Definition\Collection as DefinitionCollection;
 use my127\Workspace\Environment\Builder as EnvironmentBuilder;
@@ -61,7 +60,6 @@ class Builder implements EnvironmentBuilder
         });
 
         if ($definitions->hasType(KeyDefinition::TYPE)) {
-
             $this->application->section('secret encrypt-file')
                 ->usage('secret encrypt-file <path_to_file> [<key>]')
                 ->action(function (Input $input) {

--- a/src/Types/Workspace/Installer.php
+++ b/src/Types/Workspace/Installer.php
@@ -183,10 +183,10 @@ class Installer
     private function ensureRequiredAttributesArePresent(array $required): void
     {
         $attributes = [
-            'standard'      => [],
+            'standard' => [],
             'standard_file' => [],
-            'secret'        => [],
-            'secret_file'   => []
+            'secret' => [],
+            'secret_file' => [],
         ];
 
         foreach (['standard', 'secret'] as $type) {
@@ -200,7 +200,7 @@ class Installer
                     $response = '';
                 }
                 $attributes[$type][$attribute] = ($type == 'standard') ?
-                    $response : '= decrypt("'.$this->crypt->encrypt($response).'")';
+                    $response : '= decrypt("' . $this->crypt->encrypt($response) . '")';
             }
         }
 
@@ -222,7 +222,7 @@ class Installer
                     throw new Exception('Could not read file "' . $response . '"');
                 }
                 $attributes[$type][$attribute] = ($type == 'standard_file') ?
-                    $response : '= decrypt("'.$this->crypt->encrypt($response).'")';
+                    $response : '= decrypt("' . $this->crypt->encrypt($response) . '")';
             }
         }
 

--- a/tests/Test/Types/CryptTest.php
+++ b/tests/Test/Types/CryptTest.php
@@ -58,4 +58,20 @@ EOD
             'MY127WS_KEY' => '81a7fa14a8ceb8e1c8860031e2bac03f4b939de44fa1a78987a3fcff1bf57100',
         ])->getOutput()));
     }
+
+    /** @test */
+    public function secret_files_can_encrypted_and_decrypted_given_a_key()
+    {
+        $this->createWorkspaceYml(<<<'EOD'
+key('default'): 81a7fa14a8ceb8e1c8860031e2bac03f4b939de44fa1a78987a3fcff1bf57100
+EOD
+        );
+
+        $contents = $this->workspace()->getContents('workspace.yml');
+        $encrypted = trim($this->workspaceCommand('secret encrypt-file "workspace.yml"')->getOutput());
+        $decrypted = trim($this->workspaceCommand('secret decrypt "' . $encrypted . '"')->getOutput());
+
+        $this->assertTrue($encrypted != $contents);
+        $this->assertTrue($decrypted == $contents);
+    }
 }

--- a/tests/Test/Types/CryptTest.php
+++ b/tests/Test/Types/CryptTest.php
@@ -60,7 +60,7 @@ EOD
     }
 
     /** @test */
-    public function secret_files_can_encrypted_and_decrypted_given_a_key()
+    public function secretFilesCanEncryptedAndDecryptedGivenAKey()
     {
         $this->createWorkspaceYml(<<<'EOD'
 key('default'): 81a7fa14a8ceb8e1c8860031e2bac03f4b939de44fa1a78987a3fcff1bf57100


### PR DESCRIPTION
* Add a way to ask for a file path during `ws create`, to work around being unable to provide newlines or answers over 1024 characters.
* Add `ws secret encrypt-file <path_to_file>` to support adding whole files as encrypted content in `workspace.yml` after creation, allowing the encryption of an ssh private key, for example.
* Allow a harness to have a default attribute definition for something asked during `ws create` of `~`/`null` to avoid template render/self-documentation issues, yet still ask for a value upon `ws create`.
* Store `attribute('example'): ''` instead of `attribute('example'): null` in `workspace.yml` to stop asking questions upon `ws install` if you skipped a question by pressing enter. This allows asking optional questions and differentiates from a harness-provided "null" value
