### PR TITLE
Add config dump command

### DIFF
--- a/src/Environment/Environment.php
+++ b/src/Environment/Environment.php
@@ -38,6 +38,16 @@ class Environment
         return $this->harnessPath;
     }
 
+    /**
+     * @param string $key
+     *
+     * @return array|mixed|null
+     */
+    public function getAttribute(string $key)
+    {
+        return $this->attributes->get($key);
+    }
+
     public function build()
     {
         $this->prepareEnvironmentForBuild();

--- a/src/Types/Workspace/Builder.php
+++ b/src/Types/Workspace/Builder.php
@@ -107,6 +107,19 @@ class Builder extends Workspace implements EnvironmentBuilder, EventSubscriberIn
                     $this->workspace->run('install --step=overlay');
                     $this->workspace->run('install --step=prepare');
                 });
+
+            $this->application->section('config dump')
+                ->option('--key=<key>   Attribute key to dump.')
+                ->usage('config dump --key=<key>')
+                ->action(function(Input $input) use ($environment) {
+                    $key = $input->getOption('key');
+                    $attribute = $environment->getAttribute($key);
+                    if ($attribute === null) {
+                        echo sprintf("Attribute with key %s not found\n", $key);
+                        return;
+                    }
+                    var_dump($attribute);
+                });
         }
     }
 


### PR DESCRIPTION
While working with workspace and harnesses, I feel the need of having some way to dump the value of some specific attribute, as it's hard to find out from which config file the attribute value is being loaded, also it's being merged from multiple config files for some attributes, which makes it even harder.
So I have added this dump command to easily fetch value of a specific attribute.

Example:
```
ws config dump --key=php.ext-xdebug
array(4) {
  ["version"]=>
  string(1) "2"
  ["enable"]=>
  string(2) "no"
  ["cli"]=>
  array(1) {
    ["enable"]=>
    string(2) "no"
  }
  ["config"]=>
  array(2) {
    ["v2"]=>
    array(5) {
      ["remote_enable"]=>
      int(1)
      ["remote_autostart"]=>
      int(1)
      ["remote_port"]=>
      int(9000)
      ["remote_host"]=>
      string(20) "host.docker.internal"
      ["idekey"]=>
      string(9) "workspace"
    }
    ["v3"]=>
    array(4) {
      ["mode"]=>
      string(5) "debug"
      ["start_with_request"]=>
      string(3) "yes"
      ["client_port"]=>
      int(9003)
      ["client_host"]=>
      string(20) "host.docker.internal"
    }
  }
}
```