### PR TITLE
Add before/after overlay events and match with before for prepare

### DIFF
--- a/src/Types/Workspace/Installer.php
+++ b/src/Types/Workspace/Installer.php
@@ -82,13 +82,22 @@ class Installer
                 break;
             case self::STEP_OVERLAY:
                 if (($overlayPath = $this->workspace->getOverlayPath()) !== null) {
+                    if ($events) {
+                        $this->workspace->trigger('before.harness.overlay');
+                    }
                     $this->applyOverlayDirectory($overlayPath);
+                    if ($events) {
+                        $this->workspace->trigger('after.harness.overlay');
+                    }
                 }
                 break;
             case self::STEP_VALIDATE_ATTRIBUTES:
                 $this->ensureRequiredAttributesArePresent($this->harness->getRequiredAttributes());
                 break;
             case self::STEP_PREPARE:
+                if ($events) {
+                    $this->workspace->trigger('before.harness.prepare');
+                }
                 $this->applyConfiguration($this->harness->getRequiredConfdPaths());
                 if ($events) {
                     $this->workspace->trigger('after.harness.prepare');


### PR DESCRIPTION
before('harness.overlay') is actually better than after('harness.prepare') for project overlay confd's, as it makes it more consistent to have them renderable still in the overlay directory, where for after('harness.prepare') you would have to dst: '.my127ws/...' to get consistent behaviour

adding the rest of the before/afters for consistency as well and potentially for future other purposes