### PR TITLE
Add poweroff command

### DIFF
--- a/home/bin/ws.poweroff
+++ b/home/bin/ws.poweroff
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+set -e -o pipefail
+
+DIR=""
+
+main()
+{
+  echo "Turning off all containers..."
+
+  # Get all containers in the my127ws network
+  for containerId in $(docker ps --quiet --filter network=my127ws); do
+    # Get the docker-compose project name from the container
+    projectName="$(docker inspect --format '{{ index .Config.Labels "com.docker.compose.project"}}' "$containerId")"
+    # Get the docker-compose working directory path from the container
+    projectDirectory="$(docker inspect --format '{{ index .Config.Labels "com.docker.compose.project.working_dir"}}' "$containerId")"
+
+    if [ -z "$projectName" ] || [ -z "$projectDirectory" ]; then
+      echo "Could not look up projectName or projectDirectory for container ID '$containerId'" >&2
+      continue
+    fi
+
+    echo "Turning off $projectName's containers"
+    if [ -f "$projectDirectory/workspace.yml" ]; then
+      run "(cd '$projectDirectory' && (ws disable || docker-compose -p '$projectName' stop))"
+    elif [ -f "$projectDirectory/docker-compose.yml" ]; then
+      run "(cd '$projectDirectory' && docker-compose -p '$projectName' stop)"
+    else
+      run docker stop "$containerId"
+    fi
+  done
+}
+
+bootstrap()
+{
+    DIR="$(cd "$(dirname "$0")" && cd ../ && pwd)"
+    # shellcheck source=./lib/sidekick.sh
+    source "$DIR/lib/sidekick.sh"
+}
+
+bootstrap
+main "$@"

--- a/home/bin/ws.poweroff
+++ b/home/bin/ws.poweroff
@@ -8,6 +8,8 @@ main()
 {
   echo "Turning off all containers..."
 
+  local projects=()
+
   # Get all containers in the my127ws network
   for containerId in $(docker ps --quiet --filter network=my127ws); do
     # Get the docker-compose project name from the container
@@ -20,6 +22,11 @@ main()
       continue
     fi
 
+    if [[ "${projects[*]}" =~ (^|[[:space:]])"$projectName"($|[[:space:]]) ]]; then
+      echo "Already dealt with project $projectName, skipping" >&2
+      continue
+    fi
+
     echo "Turning off $projectName's containers"
     if [ -f "$projectDirectory/workspace.yml" ]; then
       run "(cd '$projectDirectory' && (ws disable || docker-compose -p '$projectName' stop))"
@@ -28,6 +35,8 @@ main()
     else
       run docker stop "$containerId"
     fi
+
+    projects+=("$projectName")
   done
 }
 

--- a/home/workspace.yml
+++ b/home/workspace.yml
@@ -14,6 +14,10 @@ command('create <name> [<harness> [--no-install] ]', 'create'): |
       $ws->passthru("cd $name; ws install");
   }
 
+command('poweroff', 'poweroff'): |
+  #!bash(cwd:/)
+  ws.poweroff
+
 attributes.default:
   global:
     service:


### PR DESCRIPTION
Fixes https://github.com/inviqa/harness-base-php/issues/574

Adds a `poweroff` command that looks up docker-compose projects with containers in the shared 'my127ws' network, and calls either `ws disable` or `docker-compose -p <composeProjectName> stop` on them.