### PR TITLE
#85 Fix poweroff command not being available in a harness directory

### DIFF
--- a/config/workspace/global.yml
+++ b/config/workspace/global.yml
@@ -6,3 +6,7 @@ command('global service <name> <action>', 'global service'): |
 command('global config get <key>'): |
   #!bash|=
   echo "={@(input.argument('key'))}"
+
+command('poweroff', 'poweroff'): |
+  #!bash(cwd:/)
+  ws.poweroff

--- a/home/workspace.yml
+++ b/home/workspace.yml
@@ -14,10 +14,6 @@ command('create <name> [<harness> [--no-install] ]', 'create'): |
       $ws->passthru("cd $name; ws install");
   }
 
-command('poweroff', 'poweroff'): |
-  #!bash(cwd:/)
-  ws.poweroff
-
 attributes.default:
   global:
     service:


### PR DESCRIPTION
Fixes #85 

Moving from the global harness (which defines `ws create` when not within a project directory) to the global commands list allows us to define `ws poweroff` in both non-project and project directories.