### PR TITLE
Add optional description to command type

### DIFF
--- a/config/workspace/global.yml
+++ b/config/workspace/global.yml
@@ -1,12 +1,18 @@
 
-command('global service <name> <action>', 'global service'): |
-  #!bash|=
-  ws.service ={input.argument('name')} ={input.argument('action')}
+command('global service <name> <action>', 'global service'):
+  description: Perform an action (start/stop etc.) on a global service
+  exec: |
+    #!bash|=
+    ws.service ={input.argument('name')} ={input.argument('action')}
 
-command('global config get <key>'): |
-  #!bash|=
-  echo "={@(input.argument('key'))}"
+command('global config get <key>', 'global config get'):
+  description: Retrieve a given workspace configuration by key
+  exec: |
+    #!bash|=
+    echo "={@(input.argument('key'))}"
 
-command('poweroff', 'poweroff'): |
-  #!bash(cwd:/)
-  ws.poweroff
+command('poweroff', 'poweroff'):
+  description: Completely disable workspace by shutting down all containers
+  exec: |
+    #!bash(cwd:/)
+    ws.poweroff

--- a/docs/types/command.md
+++ b/docs/types/command.md
@@ -6,6 +6,8 @@ Create simple commands to help manage your workspace.
 
 ```
 command('usage pattern', 'help page'):
+  description:
+    Optional short description, if given, will replace the default "ws <command>" on the help pages
   env:
     - NAME: Value
   exec: |

--- a/src/Types/Command/Builder.php
+++ b/src/Types/Command/Builder.php
@@ -32,6 +32,7 @@ class Builder implements EnvironmentBuilder
         /** @var Definition $definition */
         foreach ($definitions->findByType(Definition::TYPE) as $definition) {
             $this->application->section($definition->getSection())
+                ->description($definition->getDescription())
                 ->usage($definition->getUsage())
                 ->action(new Command($definition, $this->expression, $this->interpreter));
         }

--- a/src/Types/Command/Definition.php
+++ b/src/Types/Command/Definition.php
@@ -21,6 +21,9 @@ class Definition implements WorkspaceDefinition
     private $exec;
 
     /** @var string */
+    private $description;
+
+    /** @var string */
     private $path;
 
     /** @var int */
@@ -44,6 +47,11 @@ class Definition implements WorkspaceDefinition
     public function getExec(): string
     {
         return $this->exec;
+    }
+
+    public function getDescription(): string
+    {
+        return $this->description;
     }
 
     public function getPath(): string

--- a/src/Types/Command/DefinitionFactory.php
+++ b/src/Types/Command/DefinitionFactory.php
@@ -42,7 +42,7 @@ class DefinitionFactory implements WorkspaceDefinitionFactory
     {
         $this->prototype = new Definition();
 
-        foreach (['usage', 'section', 'env', 'exec', 'path', 'scope'] as $name) {
+        foreach (['usage', 'section', 'env', 'exec', 'description', 'path', 'scope'] as $name) {
             $this->properties[$name] = new ReflectionProperty(Definition::class, $name);
             $this->properties[$name]->setAccessible(true);
         }
@@ -91,6 +91,7 @@ class DefinitionFactory implements WorkspaceDefinitionFactory
         }
 
         $values['env']  = $body['env']??[];
+        $values['description']  = $body['description']??'';
         $values['exec'] = $body['exec'];
     }
 

--- a/tests/IntegrationTestCase.php
+++ b/tests/IntegrationTestCase.php
@@ -34,4 +34,9 @@ class IntegrationTestCase extends TestCase
     {
         $this->workspace()->put('workspace.yml', $contents);
     }
+
+    public function removeAnsiColorEscapes(string $content)
+    {
+        return preg_replace('/\x1b\[[0-9;]*m/', '', $content);
+    }
 }

--- a/tests/Test/Types/CommandTest.php
+++ b/tests/Test/Types/CommandTest.php
@@ -266,4 +266,61 @@ EOD
 
         $this->assertEquals("hello world", $this->workspaceCommand('hello world')->getOutput());
     }
+
+    /** @test */
+    public function command_description_is_output_with_help()
+    {
+        $this->createWorkspaceYml(<<<'EOD'
+command('speak'):
+  description: This command speaks
+  exec: |
+    #!bash
+    true
+EOD
+        );
+
+        $this->assertMatchesRegularExpression(
+            '/^\s*This command speaks\s+Usage:/s',
+            $this->removeAnsiColorEscapes($this->workspaceCommand('speak --help')->getOutput())
+        );
+    }
+
+    /** @test */
+    public function command_description_default_is_output_with_help_when_description_is_missing()
+    {
+        $this->createWorkspaceYml(<<<'EOD'
+command('speak'):
+  exec: |
+    #!bash
+    true
+EOD
+        );
+
+        $this->assertMatchesRegularExpression(
+            '/^\s*ws speak\s+Usage:/s',
+            $this->removeAnsiColorEscapes($this->workspaceCommand('speak --help')->getOutput())
+        );
+    }
+
+    /** @test */
+    public function subcommand_description_is_output_with_help()
+    {
+        $this->createWorkspaceYml(<<<'EOD'
+command('speak'):
+  exec: |
+    #!bash
+    true
+command('speak better'):
+  description: Better command speaking
+  exec: |
+    #!bash
+    true
+EOD
+        );
+
+        $this->assertMatchesRegularExpression(
+            '/Sub Commands:.*better\s+Better command speaking.*Global Options:/s',
+            $this->removeAnsiColorEscapes($this->workspaceCommand('speak --help')->getOutput())
+        );
+    }
 }

--- a/tests/Test/Types/CommandTest.php
+++ b/tests/Test/Types/CommandTest.php
@@ -310,8 +310,8 @@ command('speak'):
   exec: |
     #!bash
     true
-command('speak better'):
-  description: Better command speaking
+command('speak subcommand'):
+  description: Subcommand speaking
   exec: |
     #!bash
     true
@@ -319,7 +319,7 @@ EOD
         );
 
         $this->assertMatchesRegularExpression(
-            '/Sub Commands:.*better\s+Better command speaking.*Global Options:/s',
+            '/Sub Commands:.*subcommand\s+Subcommand speaking.*Global Options:/s',
             $this->removeAnsiColorEscapes($this->workspaceCommand('speak --help')->getOutput())
         );
     }


### PR DESCRIPTION
Allows adding an optional single line `description` property to long form `command('...')` definitions, thus reducing the need for external documentation.

This will be passed through to the application section description, and thus show up whenever the ContextualHelpPlugin usage display is invoked (on `-h` or invalid usage). my127 console will display both current and subcommand descriptions.