### PR TITLE
Fix issue with whitespace being added on empty required attributes

### DIFF
--- a/src/Types/Workspace/Installer.php
+++ b/src/Types/Workspace/Installer.php
@@ -229,7 +229,9 @@ class Installer
         array_filter($attributes);
 
         foreach ($attributes as $attributesOfType) {
-            $this->writeOutAttributes('workspace.yml', $attributesOfType);
+            if (!empty($attributesOfType)) {
+                $this->writeOutAttributes('workspace.yml', $attributesOfType);
+            }
         }
     }
 


### PR DESCRIPTION
This causes the workspace.yml to change unnecessarily, and so invalidates the docker build cache of a COPY / ...