### PR TITLE
Change non-error handled php logs to use stderr

### DIFF
--- a/bin/workspace
+++ b/bin/workspace
@@ -6,6 +6,8 @@ use my127\Workspace\Installer\Installer;
 use Symfony\Component\DependencyInjection\Container;
 use my127\Workspace\Utility\ErrorHandler;
 
+ini_set('display_errors', 'stderr');
+
 require_once __DIR__.'/../vendor/autoload.php';
 require_once __DIR__.'/../config/_compiled/container.php';
 


### PR DESCRIPTION
CLI tools should use stderr for out-of context output, so they don't interfere with machine reading of stdout

Currently we have lots of PHP deprecations on PHP 8.1, and though we could silence them, it would be nicer to solve them instead.

This PR at least allows the commands to still function