### PR TITLE
Add a `version` command and a version check for projects and harnesses

### DIFF
--- a/docs/types/harness.md
+++ b/docs/types/harness.md
@@ -1,0 +1,62 @@
+# Type - Harness
+
+When defining a harness, a harness block is used to declare common behaviour
+
+## Declaration
+
+```
+harness('name'):
+  description: Example description here
+  require:
+    workspace: '~0.3'
+```
+
+### Attributes
+
+The following attributes are automatically made available.
+
+|  Key                         |  Notes                                                         |
+|------------------------------|----------------------------------------------------------------|
+| `harness.name`               |                                                                |
+| `harness.description`        |                                                                |
+
+The following attributes can be added to change behaviour
+
+|  Key                          |  Notes                                                        |
+|-------------------------------|---------------------------------------------------------------|
+| `harness().require.services`  | A list of ws global services to launch on `ws install`        |
+| `harness().require.confd`     | A list of confd blocks to execute on `ws harness prepare`     |
+| `harness().require.workspace` | A composer/semver version constraint to force upgrade         |
+
+## Examples
+
+### A harness that implements a web server to be served by Workspace's proxy
+
+```yaml
+harness('acme-web-server'):
+  description: Example description here
+  require:
+    services:
+      - proxy
+```
+
+### A harness implementing a confd rendering
+
+```yaml
+harness('acme-templatable'):
+  description: Example description here
+  require:
+    confd:
+      - harness:/
+
+confd('harness:/'):
+  - src: template.conf
+```
+
+### A harness requiring version upgrade
+```yaml
+harness('acme-upgrade'):
+  description: Example description here
+  require:
+    workspace: '~0.3'
+```

--- a/docs/types/workspace.md
+++ b/docs/types/workspace.md
@@ -8,6 +8,9 @@ Although the only requirement for a workspace is for a `workspace.yml` file to b
 workspace('name'):
   description: Example description here
   harness: package:version
+  overlay: tools/workspace
+  require:
+    workspace: '~0.3'
 ```
 
 ### Attributes
@@ -18,17 +21,43 @@ The following attributes are automatically made available.
 |-------------------------|---------------------------------------------------------------------|
 | `workspace.name`        | When not declared the base name of the workspace directory is used. |
 | `workspace.description` |                                                                     |
-| `workspace.harness`     |                                                                     |
 | `namespace`             | Defaults to DNS friendly version of workspace name.                 |
+
+The following attributes can be added to change behaviour
+
+|  Key                            |  Notes                                                       |
+|---------------------------------|--------------------------------------------------------------|
+| `workspace().harness`           | A workspace harness to install                               |
+| `workspace().overlay`           | A directory to overlay onto the .my127ws folder              |
+| `workspace().require.workspace` | A composer/semver version constraint to force upgrade        |
 
 ## Examples
 
 ### A magento2 work environment
 
-```
+```yaml
 workspace('acme-ltd'):
   description: Example description here
   harness: magento2:latest
   
 attribute('namespace'): my-custom-namespace
+```
+
+### A project requiring version upgrade
+```yaml
+workspace('acme-upgrade'):
+  description: Example description here
+  require:
+    workspace: '~0.3'
+```
+
+### A project implementing a overlay of a harness
+
+In order to customise the harness, with overlay files in the project's tools/workspace folder
+
+```yaml
+workspace('acme-ltd'):
+  description: Example description here
+  harness: magento2:latest
+  overlay: tools/workspace
 ```

--- a/src/Terminal/Terminal.php
+++ b/src/Terminal/Terminal.php
@@ -31,4 +31,9 @@ class Terminal
     {
         $this->output->writeln($line);
     }
+
+    public function writeError(string $line)
+    {
+        $this->output->getErrorOutput()->writeln($line);
+    }
 }

--- a/src/Types/Application/Builder.php
+++ b/src/Types/Application/Builder.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace my127\Workspace\Types\Application;
+
+use my127\Workspace\Application;
+use my127\Workspace\Definition\Collection as DefinitionCollection;
+use my127\Workspace\Environment\Builder as EnvironmentBuilder;
+use my127\Workspace\Environment\Environment;
+
+class Builder implements EnvironmentBuilder
+{
+    /**
+     * @var Application
+     */
+    private $application;
+
+    public function __construct(Application $application)
+    {
+        $this->application = $application;
+    }
+
+    public function build(Environment $environment, DefinitionCollection $definitions)
+    {
+        $this->application->section('version')
+            ->usage('version')
+            ->action(function () {
+                echo Application::getVersion() . "\n";
+            });
+    }
+}

--- a/src/Types/Harness/Definition.php
+++ b/src/Types/Harness/Definition.php
@@ -62,4 +62,9 @@ class Definition implements WorkspaceDefinition
     {
         return self::TYPE;
     }
+
+    public function getRequiredWorkspaceVersion(): ?string
+    {
+        return $this->require['workspace'] ?? null;
+    }
 }

--- a/src/Types/Workspace/Builder.php
+++ b/src/Types/Workspace/Builder.php
@@ -149,13 +149,6 @@ class Builder extends Workspace implements EnvironmentBuilder, EventSubscriberIn
                     }
                     var_dump($attribute);
                 });
-
-            $application = $this->application;
-            $this->application->section('version')
-                ->usage('version')
-                ->action(function () use ($application) {
-                    echo $application::getVersion() . "\n";
-                });
         }
     }
 

--- a/src/Types/Workspace/Builder.php
+++ b/src/Types/Workspace/Builder.php
@@ -72,6 +72,8 @@ class Builder extends Workspace implements EnvironmentBuilder, EventSubscriberIn
             $this->workspace->overlay = $definition->overlay;
             /* @phpstan-ignore-next-line */
             $this->workspace->scope = $definition->scope;
+            /* @phpstan-ignore-next-line */
+            $this->workspace->require = $definition->require;
         } else {
             $this->workspace->name = basename($environment->getWorkspacePath());
             $this->workspace->description = '';
@@ -146,6 +148,13 @@ class Builder extends Workspace implements EnvironmentBuilder, EventSubscriberIn
                         return;
                     }
                     var_dump($attribute);
+                });
+
+            $application = $this->application;
+            $this->application->section('version')
+                ->usage('version')
+                ->action(function () use ($application) {
+                    echo $application::getVersion() . "\n";
                 });
         }
     }

--- a/src/Types/Workspace/Definition.php
+++ b/src/Types/Workspace/Definition.php
@@ -23,6 +23,9 @@ class Definition implements WorkspaceDefinition
     /** @var ?string */
     protected $overlay = null;
 
+    /** @var array|null */
+    protected $require;
+
     /** @var int */
     protected $scope;
 
@@ -62,5 +65,10 @@ class Definition implements WorkspaceDefinition
     public function getType(): string
     {
         return self::TYPE;
+    }
+
+    public function getRequiredWorkspaceVersion(): ?string
+    {
+        return $this->require['workspace'] ?? null;
     }
 }

--- a/src/Types/Workspace/DefinitionFactory.php
+++ b/src/Types/Workspace/DefinitionFactory.php
@@ -42,7 +42,7 @@ class DefinitionFactory implements WorkspaceDefinitionFactory
     {
         $this->prototype = new Definition();
 
-        foreach (['name', 'description', 'harnessLayers', 'path', 'overlay', 'scope'] as $name) {
+        foreach (['name', 'description', 'harnessLayers', 'path', 'overlay', 'require', 'scope'] as $name) {
             $this->properties[$name] = new ReflectionProperty(Definition::class, $name);
             $this->properties[$name]->setAccessible(true);
         }
@@ -106,6 +106,7 @@ class DefinitionFactory implements WorkspaceDefinitionFactory
         }
 
         $values['overlay'] = $body['overlay'] ?? null;
+        $values['require'] = $body['require'] ?? null;
     }
 
     public static function getTypes(): array


### PR DESCRIPTION
ws version - prints the workspace application version
the version check - checks if the workspace version satisfies composer/semver constraint in workspace().require.workspace or harness().require.workspace

projects:
```yaml
workspace('...'):
  require:
    workspace: '~0.3'
```

Harnesses:
```yaml
harness('...'):
  require:
    workspace: '~0.3'
```