### PR TITLE
Update my127/my127 to version 0.1.0 which maintains PHP 7 support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,9 @@ RUN apt-get update -qq \
  \
  # Create the build user \
  && useradd --create-home --system build \
+  # Update PHP ini values
+ && cp /usr/local/etc/php/php.ini-development /usr/local/etc/php/php.ini \
+ && sed -i 's/;phar.readonly = On/phar.readonly = Off/g' /usr/local/etc/php/php.ini \
  \
  # Install composer for PHP dependencies \
  && wget https://getcomposer.org/installer -O /tmp/composer-setup.php -q \

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "license": "MIT",
     "require": {
         "php": "^7.3 || ^8.0",
-        "my127/my127": "dev-master",
+        "my127/my127": "0.1.0",
         "symfony/config": "^4.4",
         "symfony/console": "^4.4",
         "symfony/dependency-injection": "^4.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,11 +4,11 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2a0b4c353feaaca1bc9e37fff4914df5",
+    "content-hash": "e39d43d9144316f256d1ef2a1673d631",
     "packages": [
         {
             "name": "my127/my127",
-            "version": "dev-master",
+            "version": "0.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/my127/php-library.git",
@@ -33,12 +33,11 @@
                 "phpunit/phpunit": "^9.5",
                 "squizlabs/php_codesniffer": "^3.5"
             },
-            "default-branch": true,
             "type": "library",
             "autoload": {
                 "psr-4": {
-                    "my127\\Console\\": "src/Console/src/",
-                    "my127\\FSM\\": "src/FSM/src/"
+                    "my127\\FSM\\": "src/FSM/src/",
+                    "my127\\Console\\": "src/Console/src/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -54,7 +53,7 @@
             "description": "my127 PHP Library",
             "support": {
                 "issues": "https://github.com/my127/php-library/issues",
-                "source": "https://github.com/my127/php-library/tree/master"
+                "source": "https://github.com/my127/php-library/tree/0.1.0"
             },
             "time": "2021-11-03T09:11:24+00:00"
         },
@@ -4607,14 +4606,12 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": {
-        "my127/my127": 20
-    },
+    "stability-flags": [],
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
         "php": "^7.3 || ^8.0"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.2.0"
+    "plugin-api-version": "2.3.0"
 }


### PR DESCRIPTION
The master branch of php-library is being updated to support PHP 8.x.