### PR TITLE
Display the sources of attribute in `config dump`

### DIFF
--- a/src/Definition/Loader.php
+++ b/src/Definition/Loader.php
@@ -70,6 +70,7 @@ class Loader
                     'metadata' => [
                         'path' => $directory,
                         'scope' => $scope,
+                        'file' => basename($file),
                     ],
                     'declaration' => $declaration,
                     'body' => $body,

--- a/src/Environment/Environment.php
+++ b/src/Environment/Environment.php
@@ -46,6 +46,11 @@ class Environment
         return $this->attributes->get($key);
     }
 
+    public function getAttributeMetadata(string $key): mixed
+    {
+        return $this->attributes->getAttributeMetadata($key);
+    }
+
     public function build()
     {
         $this->prepareEnvironmentForBuild();
@@ -55,7 +60,7 @@ class Environment
             $builder->build($this, $this->definitions);
         }
 
-        $this->attributes->set('host.os', strtolower(PHP_OS_FAMILY));
+        $this->attributes->set('host.os', strtolower(PHP_OS_FAMILY), 'src/Environment/Environment.php');
     }
 
     private function prepareEnvironmentForBuild()

--- a/src/Types/Attribute/Builder.php
+++ b/src/Types/Attribute/Builder.php
@@ -57,9 +57,9 @@ class Builder implements EnvironmentBuilder
             foreach ($definitions->findByType($type) as $definition) {
                 /** @var Definition $definition */
                 if ($definition->getKey() == '~') {
-                    $this->attributes->add($definition->getValue(), $this->resolveAttributePrecedence($definition));
+                    $this->attributes->add($definition->getValue(), $definition->getSource(), $this->resolveAttributePrecedence($definition));
                 } else {
-                    $this->attributes->set($definition->getKey(), $definition->getValue(), $this->resolveAttributePrecedence($definition));
+                    $this->attributes->set($definition->getKey(), $definition->getValue(), $definition->getSource(), $this->resolveAttributePrecedence($definition));
                 }
             }
         }
@@ -81,7 +81,7 @@ class Builder implements EnvironmentBuilder
                 throw new \Exception('MY127WS_ATTRIBUTES must be a YAML object.');
             }
 
-            $this->attributes->add($attributes, 10);
+            $this->attributes->add($attributes, 'Environment Variables', 10);
         }
 
         $this->expressionLanguage->addFunction(new ExpressionFunction('attr',

--- a/src/Types/Attribute/Collection.php
+++ b/src/Types/Attribute/Collection.php
@@ -95,7 +95,7 @@ class Collection
 
     public function getAttributeMetadata(string $key): mixed
     {
-        return array_key_exists($key, $this->attributeMetadata) ? $this->attributeMetadata[$key] : null;
+        return this->attributeMetadata[$key] ?? null;
     }
 
     private function getAllAttributeKeys($attributes, $parent = null): array

--- a/src/Types/Attribute/Collection.php
+++ b/src/Types/Attribute/Collection.php
@@ -158,18 +158,10 @@ class Collection implements \ArrayAccess
             if (is_array($v)) {
                 $keys = array_merge($keys, $this->getAllAttributeKeys($v, $currentKey));
             } else {
-                $this->evaluateSimpleAttributeReferencesOnly($v);
                 $keys[] = $currentKey;
             }
         }
 
         return $keys;
-    }
-
-    private function evaluateSimpleAttributeReferencesOnly(&$value)
-    {
-        if ($this->isExpression($value) && strpos($value, '(') === false) {
-            $this->evaluate($value);
-        }
     }
 }

--- a/src/Types/Attribute/Collection.php
+++ b/src/Types/Attribute/Collection.php
@@ -35,8 +35,14 @@ class Collection implements \ArrayAccess
         $this->attributeMetadata = array_merge_recursive(
             $this->attributeMetadata,
             array_fill_keys(
-                $this->getAllAttributeKeys($attributes), [0 => ['source' => $source]]
+                $this->getAllAttributeKeys($attributes), ['source' => ['_' . $precedence => $source]]
             )
+        );
+        array_walk(
+            $this->attributeMetadata,
+            function ($value) {
+                ksort($value['source']);
+            }
         );
     }
 
@@ -139,7 +145,16 @@ class Collection implements \ArrayAccess
 
     public function getAttributeMetadata(string $key): mixed
     {
-        return $this->attributeMetadata[$key] ?? null;
+        if (isset($this->attributeMetadata[$key])) {
+            if (isset($this->attributeMetadata[$key]['source'])) {
+                ksort($this->attributeMetadata[$key]['source']);
+            }
+
+            return $this->attributeMetadata[$key];
+        }
+
+        return null;
+        // return $this->attributeMetadata[$key] ?? null;
     }
 
     private function getAllAttributeKeys($attributes, $parent = null): array
@@ -152,7 +167,7 @@ class Collection implements \ArrayAccess
             if (is_array($v)) {
                 $keys = array_merge($keys, $this->getAllAttributeKeys($v, $currentKey));
             } else {
-                $keys[] = is_null($parent) ? $v : $parent . '.' . $v;
+                $keys[] = $currentKey;
             }
         }
 

--- a/src/Types/Attribute/Collection.php
+++ b/src/Types/Attribute/Collection.php
@@ -40,7 +40,7 @@ class Collection implements \ArrayAccess
         );
         array_walk(
             $this->attributeMetadata,
-            function ($value) {
+            function (&$value) {
                 ksort($value['source']);
             }
         );
@@ -145,16 +145,7 @@ class Collection implements \ArrayAccess
 
     public function getAttributeMetadata(string $key): mixed
     {
-        if (isset($this->attributeMetadata[$key])) {
-            if (isset($this->attributeMetadata[$key]['source'])) {
-                ksort($this->attributeMetadata[$key]['source']);
-            }
-
-            return $this->attributeMetadata[$key];
-        }
-
-        return null;
-        // return $this->attributeMetadata[$key] ?? null;
+        return $this->attributeMetadata[$key] ?? null;
     }
 
     private function getAllAttributeKeys($attributes, $parent = null): array
@@ -167,10 +158,18 @@ class Collection implements \ArrayAccess
             if (is_array($v)) {
                 $keys = array_merge($keys, $this->getAllAttributeKeys($v, $currentKey));
             } else {
+                $this->evaluateSimpleAttributeReferencesOnly($v);
                 $keys[] = $currentKey;
             }
         }
 
         return $keys;
+    }
+
+    private function evaluateSimpleAttributeReferencesOnly(&$value)
+    {
+        if ($this->isExpression($value) && strpos($value, '(') === false) {
+            $this->evaluate($value);
+        }
     }
 }

--- a/src/Types/Attribute/Collection.php
+++ b/src/Types/Attribute/Collection.php
@@ -10,6 +10,9 @@ class Collection implements \ArrayAccess
     /** @var mixed[][] */
     private $attributes = [];
 
+    /** @var mixed[][] */
+    private $attributeMetadata = [];
+
     /** @var Expression */
     private $expression;
 
@@ -21,7 +24,7 @@ class Collection implements \ArrayAccess
         $this->expression = $expression;
     }
 
-    public function add(array $attributes, int $precedence = 1): void
+    public function add(array $attributes, string $source, int $precedence = 1): void
     {
         if (!isset($this->attributes[$precedence])) {
             $this->attributes[$precedence] = [];
@@ -29,6 +32,11 @@ class Collection implements \ArrayAccess
 
         $this->cache = null;
         $this->attributes[$precedence] = array_replace_recursive($this->attributes[$precedence], $attributes);
+        $this->attributeMetadata = array_merge_recursive(
+            array_fill_keys(
+                $this->getAllAttributeKeys($attributes), [0 => ['source' => $source]]
+            ), $this->attributeMetadata
+        );
     }
 
     public function get(string $key, $default = null)
@@ -56,13 +64,13 @@ class Collection implements \ArrayAccess
         return $value;
     }
 
-    public function set(string $key, $value, int $precedence = 1): void
+    public function set(string $key, $value, string $source, int $precedence = 1): void
     {
         $attributes = [];
 
         Arr::set($attributes, $key, $value);
 
-        $this->add($attributes, $precedence);
+        $this->add($attributes, $source, $precedence);
     }
 
     private function evaluate(&$value): void
@@ -126,5 +134,27 @@ class Collection implements \ArrayAccess
         foreach ($this->attributes as &$attributes) {
             $this->cache = array_replace_recursive($this->cache, $attributes);
         }
+    }
+
+    public function getAttributeMetadata(string $key): mixed
+    {
+        return array_key_exists($key, $this->attributeMetadata) ? $this->attributeMetadata[$key] : null;
+    }
+
+    private function getAllAttributeKeys($attributes, $parent = null): array
+    {
+        $keys = [];
+
+        foreach ($attributes as $k => $v) {
+            $currentKey = is_null($parent) ? $k : $parent . '.' . $k;
+            $keys[] = $currentKey;
+            if (is_array($v)) {
+                $keys = array_merge($keys, $this->getAllAttributeKeys($v, $currentKey));
+            } else {
+                $keys[] = is_null($parent) ? $v : $parent . '.' . $v;
+            }
+        }
+
+        return $keys;
     }
 }

--- a/src/Types/Attribute/Collection.php
+++ b/src/Types/Attribute/Collection.php
@@ -5,7 +5,7 @@ namespace my127\Workspace\Types\Attribute;
 use my127\Workspace\Expression\Expression;
 use my127\Workspace\Utility\Arr;
 
-class Collection implements \ArrayAccess
+class Collection
 {
     /** @var mixed[][] */
     private $attributes = [];
@@ -81,49 +81,6 @@ class Collection implements \ArrayAccess
     private function isExpression($value): bool
     {
         return is_string($value) && $value != '' && $value[0] == '=';
-    }
-
-    public function offsetExists($offset): bool
-    {
-        if ($this->cache === null) {
-            $this->buildAttributeCache();
-        }
-
-        $array = &$this->cache;
-
-        if (strpos($offset, '.') === false) {
-            return array_key_exists($offset, $array);
-        }
-
-        $segments = explode('.', $offset);
-        krsort($segments);
-
-        while (($segment = array_pop($segments)) !== null) {
-            if (!array_key_exists($segment, $array)) {
-                return false;
-            }
-
-            $array = &$array[$segment];
-        }
-
-        return true;
-    }
-
-    public function offsetGet($offset): mixed
-    {
-        return $this->get($offset);
-    }
-
-    public function offsetSet($offset, $value): void
-    {
-        $this->set($offset, $value);
-    }
-
-    public function offsetUnset($offset): void
-    {
-        foreach ($this->attributes as &$attributes) {
-            Arr::forget($attributes, $offset);
-        }
     }
 
     private function buildAttributeCache()

--- a/src/Types/Attribute/Collection.php
+++ b/src/Types/Attribute/Collection.php
@@ -33,9 +33,10 @@ class Collection
         $this->cache = null;
         $this->attributes[$precedence] = array_replace_recursive($this->attributes[$precedence], $attributes);
         $this->attributeMetadata = array_merge_recursive(
+            $this->attributeMetadata,
             array_fill_keys(
                 $this->getAllAttributeKeys($attributes), [0 => ['source' => $source]]
-            ), $this->attributeMetadata
+            )
         );
     }
 
@@ -95,7 +96,7 @@ class Collection
 
     public function getAttributeMetadata(string $key): mixed
     {
-        return this->attributeMetadata[$key] ?? null;
+        return $this->attributeMetadata[$key] ?? null;
     }
 
     private function getAllAttributeKeys($attributes, $parent = null): array

--- a/src/Types/Attribute/Definition.php
+++ b/src/Types/Attribute/Definition.php
@@ -23,6 +23,9 @@ class Definition implements WorkspaceDefinition
     private $scope;
 
     /** @var string */
+    private $file;
+
+    /** @var string */
     private $type;
 
     /** @var int */
@@ -46,6 +49,16 @@ class Definition implements WorkspaceDefinition
     public function getScope(): int
     {
         return $this->scope;
+    }
+
+    public function getFile(): string
+    {
+        return $this->file;
+    }
+
+    public function getSource(): string
+    {
+        return $this->path . '/' . $this->file;
     }
 
     public function getType(): string

--- a/src/Types/Attribute/DefinitionFactory.php
+++ b/src/Types/Attribute/DefinitionFactory.php
@@ -55,7 +55,7 @@ class DefinitionFactory implements WorkspaceDefinitionFactory
     {
         $this->prototype = new Definition();
 
-        foreach (['key', 'value', 'path', 'scope', 'type', 'priority'] as $name) {
+        foreach (['key', 'value', 'path', 'scope', 'file', 'type', 'priority'] as $name) {
             $this->properties[$name] = new \ReflectionProperty(Definition::class, $name);
             $this->properties[$name]->setAccessible(true);
         }
@@ -85,6 +85,7 @@ class DefinitionFactory implements WorkspaceDefinitionFactory
     {
         $values['path'] = $metadata['path'];
         $values['scope'] = $metadata['scope'];
+        $values['file'] = $metadata['file'];
     }
 
     private function parseDeclaration(array &$values, $declaration)

--- a/src/Types/Workspace/Builder.php
+++ b/src/Types/Workspace/Builder.php
@@ -17,6 +17,7 @@ use my127\Workspace\Types\Attribute\Collection as AttributeCollection;
 use my127\Workspace\Types\Confd\Definition as ConfdDefinition;
 use my127\Workspace\Types\Harness\Definition as HarnessDefinition;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\Filesystem\Path;
 
 class Builder extends Workspace implements EnvironmentBuilder, EventSubscriberInterface
 {
@@ -152,7 +153,9 @@ class Builder extends Workspace implements EnvironmentBuilder, EventSubscriberIn
                 var_dump($attribute);
                 echo "specified in:\n";
                 array_map(
-                    function ($a) { echo $a['source'] . "\n"; }, $environment->getAttributeMetadata($key)
+                    function ($a) { 
+                        echo Path::makeRelative($a['source'], getcwd()) . "\n"; 
+                    }, $environment->getAttributeMetadata($key)
                 );
             });
     }

--- a/src/Types/Workspace/Builder.php
+++ b/src/Types/Workspace/Builder.php
@@ -94,6 +94,7 @@ class Builder extends Workspace implements EnvironmentBuilder, EventSubscriberIn
                 ],
                 'namespace' => $this->workspace->name,
             ],
+            'src/Types/Workspace/Builder.php',
             AttributeBuilder::PRECEDENCE_WORKSPACE_DEFAULT
         );
 
@@ -149,6 +150,11 @@ class Builder extends Workspace implements EnvironmentBuilder, EventSubscriberIn
                     return;
                 }
                 var_dump($attribute);
+                echo "specified in:\n";
+                array_map(
+                    function ($a) { echo $a['source'] . "\n"; }
+                    , array_reverse($environment->getAttributeMetadata($key))
+                );
             });
     }
 

--- a/src/Types/Workspace/Builder.php
+++ b/src/Types/Workspace/Builder.php
@@ -134,22 +134,22 @@ class Builder extends Workspace implements EnvironmentBuilder, EventSubscriberIn
                     $this->workspace->run('install --step=overlay');
                     $this->workspace->run('install --step=prepare');
                 });
-
-            $this->application->section('config dump')
-                ->option('--key=<key>   Attribute key to dump.')
-                ->usage('config dump --key=<key>')
-                ->action(function (Input $input) use ($environment) {
-                    $key = $input->getOption('key');
-                    $key = $key->value();
-                    $attribute = $environment->getAttribute($key);
-                    if ($attribute === null) {
-                        echo sprintf("Attribute with key %s not found\n", $key);
-
-                        return;
-                    }
-                    var_dump($attribute);
-                });
         }
+
+        $this->application->section('config dump')
+            ->option('--key=<key>   Attribute key to dump.')
+            ->usage('config dump --key=<key>')
+            ->action(function (Input $input) use ($environment) {
+                $key = $input->getOption('key');
+                $key = $key->value();
+                $attribute = $environment->getAttribute($key);
+                if ($attribute === null) {
+                    echo sprintf("Attribute with key %s not found\n", $key);
+
+                    return;
+                }
+                var_dump($attribute);
+            });
     }
 
     public function setInputGlobal(BeforeActionEvent $event)

--- a/src/Types/Workspace/Builder.php
+++ b/src/Types/Workspace/Builder.php
@@ -18,6 +18,7 @@ use my127\Workspace\Types\Confd\Definition as ConfdDefinition;
 use my127\Workspace\Types\Harness\Definition as HarnessDefinition;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Filesystem\Path;
+use Symfony\Component\Yaml\Yaml;
 
 class Builder extends Workspace implements EnvironmentBuilder, EventSubscriberInterface
 {
@@ -150,13 +151,16 @@ class Builder extends Workspace implements EnvironmentBuilder, EventSubscriberIn
 
                     return;
                 }
-                var_dump($attribute);
-                echo "specified in:\n";
+                echo "attribute value:\n\n";
+                echo preg_replace('/^/m', '    ', Yaml::dump($attribute, 99, 2));
+                echo "\nspecified in:\n\n";
                 array_map(
-                    function ($a) { 
-                        echo Path::makeRelative($a['source'], getcwd()) . "\n"; 
-                    }, $environment->getAttributeMetadata($key)
+                    function ($a) {
+                        echo '  - ' . Path::makeRelative($a, getcwd()) . "\n";
+                    },
+                    $environment->getAttributeMetadata($key)['source']
                 );
+                echo "\n";
             });
     }
 

--- a/src/Types/Workspace/Builder.php
+++ b/src/Types/Workspace/Builder.php
@@ -152,8 +152,7 @@ class Builder extends Workspace implements EnvironmentBuilder, EventSubscriberIn
                 var_dump($attribute);
                 echo "specified in:\n";
                 array_map(
-                    function ($a) { echo $a['source'] . "\n"; }
-                    , array_reverse($environment->getAttributeMetadata($key))
+                    function ($a) { echo $a['source'] . "\n"; }, array_reverse($environment->getAttributeMetadata($key))
                 );
             });
     }

--- a/src/Types/Workspace/Builder.php
+++ b/src/Types/Workspace/Builder.php
@@ -152,8 +152,8 @@ class Builder extends Workspace implements EnvironmentBuilder, EventSubscriberIn
                     return;
                 }
                 echo "attribute value:\n\n";
-                echo preg_replace('/^/m', '    ', Yaml::dump($attribute, 99, 2));
-                echo "\nspecified in:\n\n";
+                echo preg_replace('/^/m', '  ', Yaml::dump($attribute, 99, 2));
+                echo "\n\nspecified in:\n\n";
                 array_map(
                     function ($a) {
                         echo '  - ' . Path::makeRelative($a, getcwd()) . "\n";

--- a/src/Types/Workspace/Builder.php
+++ b/src/Types/Workspace/Builder.php
@@ -5,6 +5,7 @@ namespace my127\Workspace\Types\Workspace;
 use my127\Console\Application\Event\BeforeActionEvent;
 use my127\Console\Application\Executor;
 use my127\Console\Usage\Input;
+use my127\Console\Usage\Model\BooleanOptionValue;
 use my127\Workspace\Application;
 use my127\Workspace\Definition\Collection as DefinitionCollection;
 use my127\Workspace\Definition\Definition as WorkspaceDefinition;
@@ -141,6 +142,7 @@ class Builder extends Workspace implements EnvironmentBuilder, EventSubscriberIn
 
         $this->application->section('config dump')
             ->option('--key=<key>   Attribute key to dump.')
+            ->option('--simple      If set, only the final file where attribute specified is displayed.')
             ->usage('config dump --key=<key>')
             ->action(function (Input $input) use ($environment) {
                 $key = $input->getOption('key');
@@ -151,16 +153,26 @@ class Builder extends Workspace implements EnvironmentBuilder, EventSubscriberIn
 
                     return;
                 }
-                echo "attribute value:\n\n";
-                echo preg_replace('/^/m', '  ', Yaml::dump($attribute, 99, 2));
-                echo "\n\nspecified in:\n\n";
-                array_map(
-                    function ($a) {
-                        echo '  - ' . Path::makeRelative($a, getcwd()) . "\n";
-                    },
-                    $environment->getAttributeMetadata($key)['source']
-                );
-                echo "\n";
+                $simpleOutput = $input->getOption('simple');
+                $simpleOutput = $simpleOutput instanceof BooleanOptionValue ? $simpleOutput->value() : false;
+                if ($simpleOutput) {
+                    if (is_array($attribute)) {
+                        var_dump($attribute);
+                    } else {
+                        echo $attribute . "\n";
+                    }
+                } else {
+                    echo "attribute value:\n\n";
+                    echo preg_replace('/^/m', '  ', Yaml::dump($attribute, 99, 2));
+                    echo "\n\nspecified in:\n\n";
+                    array_map(
+                        function ($a) {
+                            echo '  - ' . Path::makeRelative($a, getcwd()) . "\n";
+                        },
+                        $environment->getAttributeMetadata($key)['source']
+                    );
+                    echo "\n";
+                }
             });
     }
 

--- a/src/Types/Workspace/Builder.php
+++ b/src/Types/Workspace/Builder.php
@@ -152,7 +152,7 @@ class Builder extends Workspace implements EnvironmentBuilder, EventSubscriberIn
                 var_dump($attribute);
                 echo "specified in:\n";
                 array_map(
-                    function ($a) { echo $a['source'] . "\n"; }, array_reverse($environment->getAttributeMetadata($key))
+                    function ($a) { echo $a['source'] . "\n"; }, $environment->getAttributeMetadata($key)
                 );
             });
     }

--- a/tests/Test/Types/AttributeTest.php
+++ b/tests/Test/Types/AttributeTest.php
@@ -2,9 +2,9 @@
 
 namespace Test\my127\Workspace\Types;
 
-use my127\Workspace\Tests\IntegrationTestCase;
 use my127\Workspace\Expression\Expression;
 use my127\Workspace\Path\Paths\CWD;
+use my127\Workspace\Tests\IntegrationTestCase;
 use my127\Workspace\Types\Attribute\Collection as AttributeCollection;
 
 class AttributeTest extends IntegrationTestCase
@@ -148,45 +148,45 @@ EOD
     {
         $attributes = new AttributeCollection(new Expression(new CWD()));
 
-        $attrData0 = array(
-          'level1' => array(
-            'level2a' => array(
+        $attrData0 = [
+          'level1' => [
+            'level2a' => [
               'level3a' => 'val3a',
               'level3b' => 'val3b',
-              'level3c' => 'val3c'
-            ),
-            'level2b' => array(
-              'level3d' => 'val3d'
-            )
-          )
-        );
-
-        $attrData1 = array(
-          'level1' => array(
-            'level2a' => array(
-              'level3a' => 'val3a',
-              'level3b' => 'val3b',
-              'level3c' => 'val3c'
-            ),
-            'level2b' => array(
+              'level3c' => 'val3c',
+            ],
+            'level2b' => [
               'level3d' => 'val3d',
-              'level3e' => array(
-                'level4a' => 'val4a',
-                'level4b' => 'val4b'
-              )
-            )
-          )
-        );
+            ],
+          ],
+        ];
 
-        $attrData2 = array(
-          'level1' => array(
-            'level2b' => array(
-              'level3e' => array(
-                'level4a' => 'val4a-override'
-              )
-            )
-          )
-        );
+        $attrData1 = [
+          'level1' => [
+            'level2a' => [
+              'level3a' => 'val3a',
+              'level3b' => 'val3b',
+              'level3c' => 'val3c',
+            ],
+            'level2b' => [
+              'level3d' => 'val3d',
+              'level3e' => [
+                'level4a' => 'val4a',
+                'level4b' => 'val4b',
+              ],
+            ],
+          ],
+        ];
+
+        $attrData2 = [
+          'level1' => [
+            'level2b' => [
+              'level3e' => [
+                'level4a' => 'val4a-override',
+              ],
+            ],
+          ],
+        ];
 
         $attributes->add($attrData0, 'attrData0 array', 1);
         $attributes->add($attrData2, 'attrData2 array', 5);


### PR DESCRIPTION
Related to issue #108

For discussion.

----

Relevant yaml content and output examples:
```
__common.yml__
  pipeline:
    base:
      persistence: = @('persistence')

__workspace.yml__
  persistence:
    elasticsearch:
      enabled: false

> ws config dump --key=pipeline.base.persistence.elasticsearch.enabled     
Attribute with key pipeline.base.persistence.elasticsearch.enabled not found

> ws config dump --key=pipeline.base.persistence.elasticsearch               
Attribute with key pipeline.base.persistence.elasticsearch not found

> ws config dump --key=pipeline.base.persistence  
attribute value:

  enabled: false
  mountVolumesOnConsole: true
  elasticsearch:
    enabled: false
    accessMode: ReadWriteOnce
    size: 2Gi
  mongodb:
    enabled: true
    accessMode: ReadWriteOnce
    size: 1Gi
  mysql:
    enabled: true
    accessMode: ReadWriteOnce
    size: 4Gi
  rabbitmq:
    enabled: true
    accessMode: ReadWriteOnce
    size: 2Gi
  postgres:
    enabled: true
    accessMode: ReadWriteOnce
    size: 4Gi
  redis:
    enabled: false
    accessMode: ReadWriteOnce
    size: 2Gi
  redis-session:
    enabled: true
    accessMode: ReadWriteOnce
    size: 2Gi


specified in:

  - .my127ws/harness/attributes/common.yml

> ws config dump --key=persistence                                                
attribute value:

  enabled: false
  mountVolumesOnConsole: true
  elasticsearch:
    enabled: false
    accessMode: ReadWriteOnce
    size: 2Gi
  mongodb:
    enabled: true
    accessMode: ReadWriteOnce
    size: 1Gi
  mysql:
    enabled: true
    accessMode: ReadWriteOnce
    size: 4Gi
  rabbitmq:
    enabled: true
    accessMode: ReadWriteOnce
    size: 2Gi
  postgres:
    enabled: true
    accessMode: ReadWriteOnce
    size: 4Gi
  redis:
    enabled: false
    accessMode: ReadWriteOnce
    size: 2Gi
  redis-session:
    enabled: true
    accessMode: ReadWriteOnce
    size: 2Gi


specified in:

  - .my127ws/harness/attributes/common.yml
  - workspace.yml

```
---
```
__common.yml__
  pipeline:
    base:
      persistence: = @('persistence')
      hostname:  = @('pipeline.preview.hostname')

__workspace.yml__
  pipeline:
    base:
      hostname: override-it

> ws config dump --key=pipeline.base.hostname            
attribute value:

  override-it

specified in:

  - .my127ws/harness/attributes/common.yml
  - workspace.yml
```
---
```
__workspace.yml__
  tic: 
    tac:
      toe: 1

> ws config dump --key=tic                                                         
attribute value:

  tac:
    toe: 1


specified in:

  - workspace.yml
```
---
```
__common.yml__
  pipeline:
    base:
      persistence: = @('persistence')
      hostname:  = @('pipeline.preview.hostname')

__docker-base.yml__
  pipeline:
    base:
      prometheus:
        podMonitoring: false
      services:
        mysql:
          options: = @('services.mysql.options')
        relay:
          enabled: false

__workspace.yml__
  pipeline:
    base:
      hostname: override-it

> ws config dump --key=pipeline.base                                               
attribute value:

  persistence:
    enabled: false
    mountVolumesOnConsole: true
    elasticsearch:
      enabled: false
      accessMode: ReadWriteOnce
      size: 2Gi
    mongodb:
      enabled: true
      accessMode: ReadWriteOnce
      size: 1Gi
    mysql:
      enabled: true
      accessMode: ReadWriteOnce
      size: 4Gi
    rabbitmq:
      enabled: true
      accessMode: ReadWriteOnce
      size: 2Gi
    postgres:
      enabled: true
      accessMode: ReadWriteOnce
      size: 4Gi
    redis:
      enabled: false
      accessMode: ReadWriteOnce
      size: 2Gi
    redis-session:
      enabled: true
      accessMode: ReadWriteOnce
      size: 2Gi
  hostname: override-it
  prometheus:
    podMonitoring: false
  services:
    mysql:
      options:
        default_authentication_plugin: mysql_native_password
        ignore-db-dir: ''
        max_allowed_packet: 4M
    relay:
      enabled: false


specified in:

  - .my127ws/harness/attributes/common.yml
  - .my127ws/harness/attributes/docker-base.yml
  - workspace.yml
```