### PR TITLE
Fixes #144 - Exit code and output stream changes

### DIFF
--- a/packages/Console/src/Application/Event/DisplayUsageEvent.php
+++ b/packages/Console/src/Application/Event/DisplayUsageEvent.php
@@ -7,11 +7,11 @@ use my127\Console\Usage\Parser\InputSequence;
 use my127\Console\Usage\Parser\InputSequenceFactory;
 use Symfony\Contracts\EventDispatcher\Event;
 
-class InvalidUsageEvent extends Event
+class DisplayUsageEvent extends Event
 {
     private InputSequence $input;
 
-    public function __construct($args, private OptionDefinitionCollection $options)
+    public function __construct($args, private OptionDefinitionCollection $options, private bool $validCommand = true)
     {
         $this->input = (new InputSequenceFactory())->createFrom($args, $options, true);
     }
@@ -21,8 +21,8 @@ class InvalidUsageEvent extends Event
         return clone $this->input;
     }
 
-    public function getOptions(): OptionDefinitionCollection
+    public function validCommand(): bool
     {
-        return $this->options;
+        return $this->validCommand;
     }
 }

--- a/packages/Console/src/Application/Event/InvalidUsageEvent.php
+++ b/packages/Console/src/Application/Event/InvalidUsageEvent.php
@@ -11,7 +11,7 @@ class InvalidUsageEvent extends Event
 {
     private InputSequence $input;
 
-    public function __construct($args, OptionDefinitionCollection $options)
+    public function __construct($args, private OptionDefinitionCollection $options)
     {
         $this->input = (new InputSequenceFactory())->createFrom($args, $options, true);
     }
@@ -19,5 +19,10 @@ class InvalidUsageEvent extends Event
     public function getInputSequence(): InputSequence
     {
         return clone $this->input;
+    }
+
+    public function getOptions(): OptionDefinitionCollection
+    {
+        return $this->options;
     }
 }

--- a/packages/Console/src/Application/Executor.php
+++ b/packages/Console/src/Application/Executor.php
@@ -98,7 +98,7 @@ class Executor implements SectionVisitor
         if ($this->matchedSection === null || $this->matchedInput === null) {
             $this->invalidUsage($argv);
 
-            $argvWithoutOptions = array_filter($argv, function($value) {
+            $argvWithoutOptions = array_filter($argv, function ($value) {
                 return strpos($value, '--') !== 0;
             });
 

--- a/packages/Console/src/Application/Executor.php
+++ b/packages/Console/src/Application/Executor.php
@@ -98,7 +98,15 @@ class Executor implements SectionVisitor
         if ($this->matchedSection === null || $this->matchedInput === null) {
             $this->invalidUsage($argv);
 
-            return self::EXIT_COMMAND_NOT_FOUND;
+            $argvWithoutOptions = array_filter($argv, function($value) {
+                return strpos($value, '--') !== 0;
+            });
+
+            if (count($argvWithoutOptions) == 1) {
+                return self::EXIT_OK;
+            } else {
+                return self::EXIT_COMMAND_NOT_FOUND;
+            }
         }
 
         if ($this->beforeAction()->isActionPrevented()) {

--- a/packages/Console/src/Application/Plugin/ContextualHelpPlugin.php
+++ b/packages/Console/src/Application/Plugin/ContextualHelpPlugin.php
@@ -4,7 +4,7 @@ namespace my127\Console\Application\Plugin;
 
 use my127\Console\Application\Application;
 use my127\Console\Application\Event\BeforeActionEvent;
-use my127\Console\Application\Event\InvalidUsageEvent;
+use my127\Console\Application\Event\DisplayUsageEvent;
 use my127\Console\Application\Executor;
 use my127\Console\Application\Section\Section;
 use my127\Console\Usage\Exception\NoSuchOptionException;
@@ -47,9 +47,9 @@ class ContextualHelpPlugin implements Plugin
                 }
             )
             ->on(
-                Executor::EVENT_INVALID_USAGE,
-                function (InvalidUsageEvent $e) {
-                    if ($e->getInputSequence()->count() > 2 || is_null($e->getOptions()->find('help'))) {
+                Executor::EVENT_DISPLAY_USAGE,
+                function (DisplayUsageEvent $e) {
+                    if ($e->getInputSequence()->count() > 1 && !$e->validCommand()) {
                         $style = new SymfonyStyle(new ArrayInput([]), $this->output->getErrorOutput());
                         $style->error(sprintf('Command "%s" not recognised', $e->getInputSequence()->toArgumentString()));
                     }

--- a/packages/Console/src/Application/Plugin/ContextualHelpPlugin.php
+++ b/packages/Console/src/Application/Plugin/ContextualHelpPlugin.php
@@ -49,7 +49,7 @@ class ContextualHelpPlugin implements Plugin
             ->on(
                 Executor::EVENT_INVALID_USAGE,
                 function (InvalidUsageEvent $e) {
-                    if ($e->getInputSequence()->count() > 1) {
+                    if ($e->getInputSequence()->count() > 2 || is_null($e->getOptions()->find('help'))) {
                         $style = new SymfonyStyle(new ArrayInput([]), $this->output->getErrorOutput());
                         $style->error(sprintf('Command "%s" not recognised', $e->getInputSequence()->toArgumentString()));
                     }

--- a/packages/Console/tests/Test/Application/ApplicationTest.php
+++ b/packages/Console/tests/Test/Application/ApplicationTest.php
@@ -57,13 +57,13 @@ class ApplicationTest extends TestCase
     /**
      * @test
      */
-    public function invalidUsageEventDispatchedWhenNoUsageMatchFound(): void
+    public function displayUsageEventDispatchedWhenNoUsageMatchFound(): void
     {
         $triggered = false;
 
         $application = Console::application('foo')
             ->on(
-                Executor::EVENT_INVALID_USAGE, function () use (&$triggered) {
+                Executor::EVENT_DISPLAY_USAGE, function () use (&$triggered) {
                     $triggered = true;
                 }
             )
@@ -77,6 +77,34 @@ class ApplicationTest extends TestCase
         $this->expectOutputRegex('/Usage:/');
 
         $application->run([]);
+
+        $this->assertTrue($triggered);
+    }
+
+    /**
+     * @test
+     */
+    public function displayUsageEventDispatchedWithHelpOption(): void
+    {
+        $triggered = false;
+
+        $application = Console::application('foo')
+            ->option('-h, --help    Show help message')
+            ->on(
+                Executor::EVENT_DISPLAY_USAGE, function () use (&$triggered) {
+                    $triggered = true;
+                }
+            )
+            ->usage('bar')
+            ->action(
+                function () {
+                    $this->fail('I should not be able to get here.');
+                }
+            );
+
+        $this->expectOutputRegex('/Usage:/');
+
+        $application->run(['foo', '--help bar']);
 
         $this->assertTrue($triggered);
     }

--- a/tests/Test/Application/ApplicationTest.php
+++ b/tests/Test/Application/ApplicationTest.php
@@ -36,4 +36,60 @@ class ApplicationTest extends IntegrationTestCase
         $process->run();
         self::assertStringNotContainsString('not recognised', $process->getErrorOutput());
     }
+
+    public function testExitsWithZeroExitCodeWithNoCommand(): void
+    {
+        self::assertEquals(
+            Executor::EXIT_OK,
+            $this->workspaceProcess('')->run()
+        );
+    }
+
+    public function testExitsWithZeroExitCodeWithLongHelpOption(): void
+    {
+        self::assertEquals(
+            Executor::EXIT_OK,
+            $this->workspaceProcess('--help')->run()
+        );
+    }
+
+    public function testExitsWithZeroExitCodeWithShortHelpOption(): void
+    {
+        self::assertEquals(
+            Executor::EXIT_OK,
+            $this->workspaceProcess('-h')->run()
+        );
+    }
+
+    public function testExitsWithZeroExitCodeWithLongHelpOptionOnValidCommand(): void
+    {
+        self::assertEquals(
+            Executor::EXIT_OK,
+            $this->workspaceProcess('--help version')->run()
+        );
+    }
+
+    public function testExitsWithZeroExitCodeWithShortHelpOptionOnValidCommand(): void
+    {
+        self::assertEquals(
+            Executor::EXIT_OK,
+            $this->workspaceProcess('-h version')->run()
+        );
+    }
+
+    public function testExitsWithCommandNotFoundExitCodeWithLongHelpOptionOnInvalidCommand(): void
+    {
+        self::assertEquals(
+            Executor::EXIT_COMMAND_NOT_FOUND,
+            $this->workspaceProcess('--help idonotexist')->run()
+        );
+    }
+
+    public function testExitsWithCommandNotFoundExitCodeWithShortHelpOptionOnInvalidCommand(): void
+    {
+        self::assertEquals(
+            Executor::EXIT_COMMAND_NOT_FOUND,
+            $this->workspaceProcess('-h idonotexist')->run()
+        );
+    }
 }


### PR DESCRIPTION
### Tests

**1. ws alone shall be exit 0 and stdout**

**2a. ws --help shall be exit 0 and stdout**

**2b. ws -h shall be exit 0 and stdout**


**3a. ws --help command shall be exit 0 and stdout**

**3b. ws -h command shall be exit 0 and stdout**


**4a. ws --help badcommand shall be exit 127 and stderr**

**4b. ws -h badcommand shall be exit 127 and stderr**


**5a. ws --help shall not throw an error (command "" does not exist)**

**5b. ws -h shall not throw an error (command "" does not exist)**


**6. ws badcommand shall be exit 127 and stderr**

fixes #144 
