### PR TITLE
Avoid using addslashes in bash executor and pass in safely

### DIFF
--- a/src/Interpreter/Executors/Bash/Executor.php
+++ b/src/Interpreter/Executors/Bash/Executor.php
@@ -69,6 +69,11 @@ class Executor implements InterpreterExecutor
         return self::NAME;
     }
 
+    /**
+     * @param string[] $args arguments to the command
+     *
+     * @return string[]
+     **/
     private function buildCommand(string $script, array $args, ?string $cwd): array
     {
         $home = home();

--- a/tests/Test/Interpreters/BashTest.php
+++ b/tests/Test/Interpreters/BashTest.php
@@ -21,4 +21,95 @@ EOD
             $this->workspaceCommand('speak')->getOutput()
         );
     }
+
+    public function bashCanReceiveParentEnvironmentVariables()
+    {
+        putenv('MESSAGE=Hello World');
+        $this->createWorkspaceYml(<<<'EOD'
+command('speak'):
+  exec: |
+    #!bash
+    echo -n "$MESSAGE"
+EOD
+        );
+
+        $this->assertEquals(
+            'Hello World',
+            $this->workspaceCommand('speak')->getOutput()
+        );
+    }
+
+    public function bashCanReceiveCustomEnvironmentVariables()
+    {
+        $this->createWorkspaceYml(<<<'EOD'
+command('speak'):
+  env:
+    MESSAGE: Hello World
+  exec: |
+    #!bash
+    echo -n "$MESSAGE"
+EOD
+        );
+
+        $this->assertEquals(
+            'Hello World',
+            $this->workspaceCommand('speak')->getOutput()
+        );
+    }
+
+    public function bashCanReceiveParentEnvironmentVariablesWhileCustomUsed()
+    {
+        putenv('REAL_MESSAGE=Hello World');
+        $this->createWorkspaceYml(<<<'EOD'
+command('speak'):
+  env:
+    MESSAGE: I'm sorry Dave, I'm afraid I can't do that
+  exec: |
+    #!bash
+    echo -n "$REAL_MESSAGE"
+EOD
+        );
+
+        $this->assertEquals(
+            'Hello World',
+            $this->workspaceCommand('speak')->getOutput()
+        );
+    }
+
+    public function bashCanReceiveOverrideParentEnvironmentVariables()
+    {
+        putenv('MESSAGE=I should be overridden');
+        $this->createWorkspaceYml(<<<'EOD'
+command('speak'):
+  env:
+    MESSAGE: Hello World
+  exec: |
+    #!bash
+    echo -n "$MESSAGE"
+EOD
+        );
+
+        $this->assertEquals(
+            'Hello World',
+            $this->workspaceCommand('speak')->getOutput()
+        );
+    }
+
+    public function bashCanReceiveQuotesInEnvironmentVariables()
+    {
+        $this->createWorkspaceYml(<<<'EOD'
+command('speak'):
+  env:
+    MESSAGE: someone said 'Hello World'
+  exec: |
+    #!bash
+    echo -n "$MESSAGE"
+EOD
+        );
+
+        $this->assertEquals(
+            'someone said \'Hello World\'',
+            $this->workspaceCommand('speak')->getOutput()
+        );
+    }
 }


### PR DESCRIPTION
This means the following characters will be processed as literals rather than escaped in ways that don't work in some circumstances:

* single quote `'`
* double quote `"`
* backslash `\`

As literals, whether in `$VARNAME` `'$VARNAME'` `"$VARNAME"`, they will be literals in there too (as in not processed as their scripting/shell varients).

The issue before was that when setting the variable `VARNAME: "'test'"` resulted in  `export VARNAME="\'test\'"` from addslashes adding `\` literals, making the literal value `\'test\'`, which instead will no longer be the case, making the literal value `'test'`. 

It was fine before for `"` and `\` since they needed escaping to be literals within `"..."`.

A side-effect of this change is also that `$` will be processed literal, whereas before it was possible to do:
```
command('...'):
  env:
    VAR: "$USER"
  exec:
    #!bash
    echo "$VAR" //  before: prints expansion of `$USER`, after: prints `$USER`
```

Note:
* proc_open supports an env parameter, but needs explicit adding of previous env as well if used
* bash scripts can receive positional arguments, so use them and map them back to their bash variable name
  * arguments are not exposed as an option anywhere yet, other than through expressions in env
* proc_open supports auto-escaping of array commands
* proc_open supports cwd setting as well, but I'm avoiding it due to not supporting relative path unlike the cd in the script