### PR TITLE
MISC support for fakeowner mount type

### DIFF
--- a/tools/builder/root/entrypoint.sh
+++ b/tools/builder/root/entrypoint.sh
@@ -27,7 +27,9 @@ resolve_volume_mount_strategy()
             STRATEGY="host-osx-normal"
         elif (mount | grep "/app type fuse.grpcfuse") > /dev/null 2>&1; then
             STRATEGY="host-osx-normal"
-        elif (mount | grep "/app type virtiofs") > /dev/null 2>&1; then
+        elif (mount | grep "/app type virtiofs") > /dev/null 2>&1; then # virtiofs (Docker Desktop < 4.15)
+            STRATEGY="host-osx-normal"
+        elif (mount | grep "/app type fakeowner") > /dev/null 2>&1; then # virtiofs (Docker Desktop >= 4.15)
             STRATEGY="host-osx-normal"
         else
             exit 1


### PR DESCRIPTION
Add support for fakeowner mount type used in Docker Desktop >=4.15 for the builder container used to test and build Workspace during the development process